### PR TITLE
Fix "buildpack-select" setting shell variables

### DIFF
--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -6,7 +6,8 @@ buildpack-build() {
 	declare desc="Build an application using installed buildpacks"
 	ensure-paths
 	buildpack-setup > /dev/null
-	buildpack-select | indent
+	# use "process substitution" so buildpack-select can set variables in this shell
+	buildpack-select > >(indent)
 	buildpack-compile | indent
 	procfile-types | indent
 }


### PR DESCRIPTION
The "buildpack-select" function sets "selected_path", but it was not being
persisted in the parent shell, in order to be used from "buildpack-compile".
The function appears to have been run in a subshell as a result of piping the
output to "indent". This changes it to use "process substitution" to pass the
output to "indent" while "buildpack-select" runs in the parent shell.

I was trying out herokuish in a Docker image based on "progrium/cedarish".

```
$ bash --version
GNU bash, version 4.3.11(1)-release (x86_64-pc-linux-gnu)
```

Without this change, I would get an error like this running `herokuish buildpack build` because `selected_path` was not propagated to `buildpack-compile`:

```
-----> Python app detected
setuidgid: fatal: unable to run /bin/compile: file does not exist
```

With this change, the variables are set, and the output still seems to be piped correctly through `indent` (tested with some dummy `echo` calls in `buildpack-select`).
