### PR TITLE
Compress slug when pigz is not installed

### DIFF
--- a/include/slug.bash
+++ b/include/slug.bash
@@ -15,15 +15,15 @@ slug-import() {
 
 slug-generate() {
 	declare desc="Generate a gzipped slug tarball from the current app"
-	local pigz_option
+	local compress_option="-z"
 	if which pigz > /dev/null; then
-		pigz_option="--use-compress-program=pigz"
+		compress_option="--use-compress-program=pigz"
 	fi
 	local slugignore_option
 	if [[ -f "$app_path/.slugignore" ]]; then
 		slugignore_option="-X $app_path/.slugignore"
 	fi
-	tar $pigz_option $slugignore_option \
+	tar $compress_option $slugignore_option \
 		--exclude='.git' \
 		-C "$app_path" \
 		-cf "$slug_path" \

--- a/tests/functional/tests.sh
+++ b/tests/functional/tests.sh
@@ -9,6 +9,7 @@ cedarish-run() {
 	}
 	check-cedarish || import-cedarish
 	declare -f $1 | tail -n +2 | docker run --rm -i -v "$PWD:/test" "$cedarish_image:$cedarish_version" bash
+	assertTrue "$1 failed" "$?"
 }
 
 test-binary() {
@@ -17,4 +18,14 @@ test-binary() {
 		exit
 	}
 	cedarish-run _testBinary
+}
+
+test-generate() {
+	_testGenerate() {
+		mkdir /app
+		/test/build/linux/herokuish slug generate
+		tar tzf /tmp/slug.tgz
+		exit
+	}
+	cedarish-run _testGenerate
 }


### PR DESCRIPTION
This adds a fallback to the "-z" option so that "slug.tgz" is still compressed
even when pigz is not installed.

I added a test as well which fails when the tarball is not compressed.  I'm not sure about the best practices for shunit tests here, but with the addition of the assertion in `cedarish-run`, it will fail when expected.
