### PR TITLE
Try shallow cloning buildpack repos

### DIFF
--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -20,10 +20,16 @@ buildpack-install() {
 	fi
 	local target_path="$buildpack_path/${name:-$(basename $url)}"
 	if [[ "$commit" ]]; then
-		git clone "$url" "$target_path"
-		cd "$target_path"
-		git checkout --quiet "$commit"
-		cd - > /dev/null
+		if ! git clone --branch "$commit" --quiet --depth 1 "$url" "$target_path" &>/dev/null; then
+			# if the shallow clone failed partway through, clean up and try a full clone
+			rm -rf "$target_path"
+			git clone "$url" "$target_path"
+			cd "$target_path"
+			git checkout --quiet "$commit"
+			cd - > /dev/null
+		else
+			echo "Cloned into '$target_path'..."
+		fi
 	else
 		git clone --depth=1 "$url" "$target_path"
 	fi

--- a/tests/util/run-app
+++ b/tests/util/run-app
@@ -7,7 +7,7 @@ check-buildpacks() {
 }
 
 download-buildpacks() {
-	docker run --name herokuish-buildpacks \
+	time docker run --name herokuish-buildpacks \
 		-v /tmp/buildpacks \
 		-v "$PWD:/mnt" \
 		"$cedarish_image:$cedarish_version" \


### PR DESCRIPTION
Try to shallow clone buildpack repositories before falling back to deep
cloning. This improves clone times significantly.

Based on https://github.com/gliderlabs/herokuish/pull/6, Deis PR https://github.com/deis/deis/pull/2988