### PR TITLE
Added Play V1 example app

### DIFF
--- a/bindata.go
+++ b/bindata.go
@@ -76,12 +76,12 @@ func include_buildpack_bash() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "include/buildpack.bash", size: 3008, mode: os.FileMode(420), modTime: time.Unix(1421346661, 0)}
+	info := bindata_file_info{name: "include/buildpack.bash", size: 3008, mode: os.FileMode(420), modTime: time.Unix(1423000598, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
 
-var _include_buildpacks_txt = []byte("\x1f\x8b\x08\x00\x00\x09\x6e\x88\x00\xff\x94\x90\x31\x92\x85\x20\x10\x44\x73\x4f\xe1\x05\x5c\x57\x70\xd5\xda\xdb\x0c\xc3\x28\x2a\x0a\x85\x40\x95\xb7\xff\x89\xf5\x25\x9d\x4e\x88\xde\xeb\x66\x4c\x8c\xfe\xfa\x6f\xdb\x65\x8d\x26\xa9\x1f\x74\x47\x6b\x28\xb8\x3d\x3d\x4f\xa3\xd2\x6a\xb5\x07\xdc\x1b\xb4\x6e\x4b\x81\xea\x27\x0a\x85\x9a\xf5\x54\x31\x0c\x8b\xab\xcb\x28\x31\x74\x00\x8a\x65\x08\xa0\xed\x77\x42\x3d\xf6\x72\x1e\x25\x72\x0c\x1b\x64\x28\x36\x64\x29\x39\xf4\x91\x6c\x5c\x5f\x1a\xb5\x26\x94\x3d\xc7\x70\x3a\x4d\xdb\xf5\xf6\x0f\xbf\x1c\xda\x1b\x5f\x5e\x30\xf7\xac\xf5\xde\xc2\x5d\xd0\x48\xa4\x69\x1a\x58\x86\x3b\x1a\x77\xbe\xfd\x7f\x82\x43\x87\xa4\xca\xfe\xdc\x89\x91\x83\x5f\x08\x16\xca\xcf\x77\xd5\x27\x00\x00\xff\xff\x18\xb8\xea\x1e\xbf\x02\x00\x00")
+var _include_buildpacks_txt = []byte("\x1f\x8b\x08\x00\x00\x09\x6e\x88\x00\xff\x94\xd0\x41\x12\x83\x20\x0c\x05\xd0\xbd\xa7\xf0\x02\xd6\x0a\x56\x3b\xbd\x4d\x12\x50\x54\x14\x06\xc1\x19\x6f\xdf\x8d\x53\xe9\x32\xd9\xb0\x7a\x3f\x9f\x98\x18\xfd\xfe\xa9\xeb\x71\x8a\x26\xe1\x83\xdc\x5a\x1b\x1d\xdc\x92\xae\xa7\xc2\x34\x59\xe5\x81\x96\x8a\xac\x9b\x53\xd0\xe5\x35\x48\x02\x07\xf5\x2e\x18\x09\xa3\x2b\xf3\x41\xd1\x35\x00\xc8\x4a\x08\xa0\xec\xaf\x42\xd9\xb7\x72\xe8\x25\x71\x12\x66\x38\x20\xeb\x70\x48\xc9\xd1\x6b\xb2\x71\xba\x35\x29\xa5\x49\xb6\x9c\x84\xcd\x29\x3d\xef\xf7\xfe\xee\xc9\xd1\xde\xf8\xfc\x82\x47\xcb\x6a\xef\x2d\x9c\xb9\x16\x3c\x7d\x46\xe3\xb6\x5b\xbf\x04\x47\x87\x84\x7f\xbb\x1b\xd1\x73\xf8\x4e\x60\x21\xff\x78\x53\x7c\x03\x00\x00\xff\xff\x0f\x7a\x75\xda\xbb\x02\x00\x00")
 
 func include_buildpacks_txt_bytes() ([]byte, error) {
 	return bindata_read(
@@ -96,7 +96,7 @@ func include_buildpacks_txt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "include/buildpacks.txt", size: 703, mode: os.FileMode(420), modTime: time.Unix(1421340737, 0)}
+	info := bindata_file_info{name: "include/buildpacks.txt", size: 699, mode: os.FileMode(420), modTime: time.Unix(1423000598, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -116,7 +116,7 @@ func include_cedarish_txt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "include/cedarish.txt", size: 3, mode: os.FileMode(420), modTime: time.Unix(1422986651, 0)}
+	info := bindata_file_info{name: "include/cedarish.txt", size: 3, mode: os.FileMode(420), modTime: time.Unix(1423000602, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -136,7 +136,7 @@ func include_cmd_bash() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "include/cmd.bash", size: 1604, mode: os.FileMode(420), modTime: time.Unix(1416876705, 0)}
+	info := bindata_file_info{name: "include/cmd.bash", size: 1604, mode: os.FileMode(420), modTime: time.Unix(1422884875, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -156,7 +156,7 @@ func include_fn_bash() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "include/fn.bash", size: 547, mode: os.FileMode(420), modTime: time.Unix(1416714978, 0)}
+	info := bindata_file_info{name: "include/fn.bash", size: 547, mode: os.FileMode(420), modTime: time.Unix(1422884875, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -176,7 +176,7 @@ func include_herokuish_bash() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "include/herokuish.bash", size: 2774, mode: os.FileMode(420), modTime: time.Unix(1421351057, 0)}
+	info := bindata_file_info{name: "include/herokuish.bash", size: 2774, mode: os.FileMode(420), modTime: time.Unix(1422999670, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -196,7 +196,7 @@ func include_procfile_bash() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "include/procfile.bash", size: 1580, mode: os.FileMode(420), modTime: time.Unix(1421347263, 0)}
+	info := bindata_file_info{name: "include/procfile.bash", size: 1580, mode: os.FileMode(420), modTime: time.Unix(1422999670, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -216,7 +216,7 @@ func include_slug_bash() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "include/slug.bash", size: 1139, mode: os.FileMode(420), modTime: time.Unix(1418873487, 0)}
+	info := bindata_file_info{name: "include/slug.bash", size: 1139, mode: os.FileMode(420), modTime: time.Unix(1422884875, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }

--- a/include/buildpacks.txt
+++ b/include/buildpacks.txt
@@ -5,7 +5,7 @@ https://github.com/heroku/heroku-buildpack-java           v33
 https://github.com/heroku/heroku-buildpack-multi          cddec34
 https://github.com/heroku/heroku-buildpack-nodejs         v60
 https://github.com/heroku/heroku-buildpack-php            v43
-https://github.com/heroku/heroku-buildpack-play           ceede86
+https://github.com/heroku/heroku-buildpack-play           v23
 https://github.com/heroku/heroku-buildpack-python         v52
 https://github.com/heroku/heroku-buildpack-ruby           v127
 https://github.com/heroku/heroku-buildpack-scala          v41

--- a/tests/apps/play-v1/Procfile
+++ b/tests/apps/play-v1/Procfile
@@ -1,0 +1,1 @@
+web: play run --http.port=$PORT $PLAY_OPTS

--- a/tests/apps/play-v1/README.md
+++ b/tests/apps/play-v1/README.md
@@ -1,0 +1,96 @@
+# Play Quick Start Guide
+
+This guide will walk you through deploying a Play application on Deis.
+
+## Usage
+
+    $ deis create
+    Creating application... done, created quinoa-macaroni
+    Git remote deis added
+    $ git push deis master
+    Counting objects: 86, done.
+    Delta compression using up to 4 threads.
+    Compressing objects: 100% (74/74), done.
+    Writing objects: 100% (86/86), 91.96 KiB | 0 bytes/s, done.
+    Total 86 (delta 13), reused 0 (delta 0)
+    -----> Play! app detected
+    -----> Installing OpenJDK 1.6... done
+    -----> Installing Play! 1.3.0.....
+    -----> done
+    -----> Building Play! application...
+           ~        _            _
+           ~  _ __ | | __ _ _  _| |
+           ~ | '_ | |/ _' | || |_|
+           ~ |  __/|_|____|__ (_)
+           ~ |_|            |__/
+           ~
+           ~ play! 1.3.0, https://www.playframework.com
+           ~
+           1.3.0
+           Building Play! application at directory ./
+           Resolving dependencies: .play/play dependencies ./ --forProd --forceCopy --silent -Duser.home=/tmp/build 2>&1
+           ~ Resolving dependencies using /tmp/build/conf/dependencies.yml,
+           ~
+           ~
+           ~ No dependencies to install
+           ~
+           ~ Done!
+           ~
+           Precompiling: .play/play precompile ./ --silent 2>&1
+           Listening for transport dt_socket at address: 8000
+           15:42:35,694 INFO  ~ Starting /tmp/build
+           :: loading settings :: url = jar:file:/tmp/build/.play/framework/lib/ivy-2.3.0.jar!/org/apache/ivy/core/settings/ivysettings.xml
+           15:42:36,791 INFO  ~ Precompiling ...
+           Jan 30, 2015 3:42:39 PM org.codehaus.groovy.runtime.m12n.MetaInfExtensionModule newModule
+           WARNING: Module [groovy-all] - Unable to load extension class [org.codehaus.groovy.runtime.NioGroovyMethods]
+           15:42:46,273 INFO  ~ Done.
+           ~ using java version "1.6.0_27"
+    -----> Discovering process types
+           Procfile declares types -> web
+    -----> Compiled slug size is 84M
+
+    -----> Building Docker image
+    remote: Sending build context to Docker daemon 87.32 MB
+    remote: build context to Docker daemon
+    Step 0 : FROM deis/slugrunner
+     ---> 7474b542af26
+    Step 1 : RUN mkdir -p /app
+     ---> Running in 15e5f7e98502
+     ---> 1ef08045ea6c
+    Removing intermediate container 15e5f7e98502
+    Step 2 : WORKDIR /app
+     ---> Running in d19670e296b0
+     ---> 471fc8e5a374
+    Removing intermediate container d19670e296b0
+    Step 3 : ENTRYPOINT /runner/init
+     ---> Running in b8458526e774
+     ---> 2e360120165d
+    Removing intermediate container b8458526e774
+    Step 4 : ADD slug.tgz /app
+     ---> 97cb51d6e197
+    Removing intermediate container 0760260339ca
+    Step 5 : ENV GIT_SHA 59303a00650091685e13cc055c3b9437ce4e7ff8
+     ---> Running in 547ee6f35db3
+     ---> aa496469ed62
+    Removing intermediate container 547ee6f35db3
+    Successfully built aa496469ed62
+    -----> Pushing image to private registry
+
+    -----> Launching...
+           done, quinoa-macaroni:v2 deployed to Deis
+
+           http://quinoa-macaroni.local3.deisapp.com
+
+           To learn more, use `deis help` or visit http://deis.io
+
+    To ssh://git@deis.local3.deisapp.com:2222/quinoa-macaroni.git
+     * [new branch]      master -> master
+    $ curl -s http://quinoa-macaroni.local3.deisapp.com
+    Powered by Deis
+
+## Additional Resources
+
+* [Get Deis](http://deis.io/get-deis/)
+* [GitHub Project](https://github.com/deis/deis)
+* [Documentation](http://docs.deis.io/)
+* [Blog](http://deis.io/blog/)

--- a/tests/apps/play-v1/app/controllers/Application.java
+++ b/tests/apps/play-v1/app/controllers/Application.java
@@ -1,0 +1,16 @@
+package controllers;
+
+import play.*;
+import play.mvc.*;
+
+import java.util.*;
+
+import models.*;
+
+public class Application extends Controller {
+
+    public static void index() {
+        renderText("play-v1\n");
+    }
+
+}

--- a/tests/apps/play-v1/conf/application.conf
+++ b/tests/apps/play-v1/conf/application.conf
@@ -1,0 +1,54 @@
+# This is the main configuration file for the application.
+# ~~~~~
+application.name=example-play
+
+# Application mode
+# ~~~~~
+# Set to dev to enable instant reloading and other development help.
+# Otherwise set to prod.
+application.mode=dev
+%prod.application.mode=prod
+
+# Secret key
+# ~~~~~
+# The secret key is used to secure cryptographics functions
+# If you deploy your application to several instances be sure to use the same key !
+application.secret=Wyf4eh5AOfwWluyyYR9Y6rTov316YkmcbHc2OVjs84qfIFnBQE32Uf2QC90TELOD
+
+# Date format
+# ~~~~~
+date.format=yyyy-MM-dd
+# date.format.fr=dd/MM/yyyy
+
+# JPA Configuration (Hibernate)
+# ~~~~~
+#
+# Specify the custom JPA dialect to use here (default to guess):
+# jpa.default.dialect=org.hibernate.dialect.PostgreSQLDialect
+#
+# Specify the ddl generation pattern to use. Set to none to disable it
+# (default to update in DEV mode, and none in PROD mode):
+# jpa.default.ddl=update
+#
+# Debug SQL statements (logged using DEBUG level):
+# jpa.default.debugSQL=true
+#
+# You can even specify additional hibernate properties here:
+# default.hibernate.use_sql_comments=true
+# ...
+#
+# Store path for Blob content
+attachments.path=data/attachments
+
+# Mail configuration
+# ~~~~~
+# Default is to use a mock Mailer
+mail.smtp=mock
+
+# Testing. Set up a custom configuration for test mode
+# ~~~~~
+#%test.module.cobertura=${play.path}/modules/cobertura
+%test.application.mode=dev
+%test.db.url=jdbc:h2:mem:play;MODE=MYSQL;LOCK_MODE=0
+%test.jpa.ddl=create
+%test.mail.smtp=mock

--- a/tests/apps/play-v1/conf/dependencies.yml
+++ b/tests/apps/play-v1/conf/dependencies.yml
@@ -1,0 +1,4 @@
+# Application dependencies
+
+require:
+    - play 1.3.0

--- a/tests/apps/play-v1/conf/routes
+++ b/tests/apps/play-v1/conf/routes
@@ -1,0 +1,15 @@
+# Routes
+# This file defines all application routes (Higher priority routes first)
+# ~~~~
+
+# Home page
+GET     /                                       Application.index
+
+# Ignore favicon requests
+GET     /favicon.ico                            404
+
+# Map static resources from the /app/public folder to the /public path
+GET     /public/                                staticDir:public
+
+# Catch all
+*       /{controller}/{action}                  {controller}.{action}

--- a/tests/apps/play-v1/test/Application.test.html
+++ b/tests/apps/play-v1/test/Application.test.html
@@ -1,0 +1,7 @@
+*{ You can use plain selenium command using the selenium tag }*
+
+#{selenium}
+    // Open the home page, and check that no error occured
+    open('/')
+    assertNotTitle('Application error')
+#{/selenium}

--- a/tests/apps/play-v1/test/ApplicationTest.java
+++ b/tests/apps/play-v1/test/ApplicationTest.java
@@ -1,0 +1,17 @@
+import org.junit.*;
+import play.test.*;
+import play.mvc.*;
+import play.mvc.Http.*;
+import models.*;
+
+public class ApplicationTest extends FunctionalTest {
+
+    @Test
+    public void testThatIndexPageWorks() {
+        Response response = GET("/");
+        assertIsOk(response);
+        assertContentType("text/plain", response);
+        assertCharset(play.Play.defaultWebEncoding, response);
+    }
+
+}

--- a/tests/apps/play-v1/tests.sh
+++ b/tests/apps/play-v1/tests.sh
@@ -1,0 +1,6 @@
+
+source "$(dirname $BASH_SOURCE)/../runner.sh"
+
+test-z2-app-play-v1() {
+  run-app-test play-v1 "play-v1"
+}


### PR DESCRIPTION
The play buildpack only works for play 1.x apps. Play 2.0 apps are using the scala buildpack

https://github.com/heroku/heroku-buildpack-play#heroku-buildpack-play
> Note: This buildpack only applies to Play 1.2.x apps. Play 2.x apps are handled by the Scala buildpack

Deis PR: https://github.com/deis/example-play/pull/1
Based on: https://github.com/gliderlabs/herokuish/pull/6