### PR TITLE
only run `release` if present

### DIFF
--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -102,7 +102,9 @@ buildpack-execute() {
 
 	cd "$build_path"
 	unprivileged "$selected_path/bin/compile" "$build_path" "$cache_path" "$env_path"
-	unprivileged "$selected_path/bin/release" "$build_path" "$cache_path" > "$build_path/.release"
+	if [[ -f "$selected_path/bin/release" ]]; then
+		unprivileged "$selected_path/bin/release" "$build_path" "$cache_path" > "$build_path/.release"
+	fi
 	cd - > /dev/null
 
 	shopt -s dotglob nullglob


### PR DESCRIPTION
The `release` script is not required for Heroku buildspacks, check for it before running.

Heroku docs: https://devcenter.heroku.com/articles/buildpack-api#bin-release