### PR TITLE
initial pass at building herokuish in a docker container

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,2 @@
+FROM golang:1.4-cross
+RUN curl -s -o - https://get.docker.com/builds/Linux/x86_64/docker-1.6.2 > /usr/local/bin/docker && chmod +x /usr/local/bin/docker


### PR DESCRIPTION
The reasoning behind this is to allow dokku (or any other client) to be able to build herokuish from master and not be pinned to the release as defined in the Dockerfile