### PR TITLE
Increased CURL_TIMEOUT env var in buildpacks from the default 30 to 180

### DIFF
--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -60,6 +60,8 @@ buildpack-setup() {
 
 	# Useful settings / features
 	export CURL_CONNECT_TIMEOUT="30"
+	export CURL_TIMEOUT="180"
+
 
 	# Buildstep backwards compatibility
 	if [[ -f "$app_path/.env" ]]; then


### PR DESCRIPTION
I have consistently ran into timeouts downloading buildpacks when running herokuish locally for testing and development, so I overrided the default env var from 30 seconds to 180.

    Command: 'set -o pipefail; curl --fail --retry 3 --retry-delay 1 --connect-timeout 30 --max-time 30 https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/cedar-14/ruby-2.2.2.tgz -s -o - | tar zxf - ' failed unexpectedly:
           !
           !     gzip: stdin: invalid compressed data--format violated```