### PR TITLE
throw error when detect fails in custom buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,40 @@ Mounting your local app source directory to `/tmp/app` and running `/bin/herokui
 -----> Compiling Ruby/Rack
 -----> Using Ruby version: ruby-1.9.3
   ...
-	
+
 ```
 
 You can use this output when you submit issues.
+
+#### Troubleshooting
+
+If you run into an issue and looking for more insight into what `herokuish` is doing, you can set the `$TRACE` environment variable.
+
+```
+$ docker run --rm -e TRACE=true -v /abs/app/path:/tmp/app gliderlabs/herokuish /bin/herokuish test
++ [[ -d /tmp/app ]]
++ rm -rf /app
++ cp -r /tmp/app /app
++ cmd-export paths
++ declare 'desc=Exports a function as a command'
++ declare fn=paths as=paths
++ local ns=
+++ cmd-list-ns
+++ sort
+++ grep -v :
+++ for k in '"${!CMDS[@]}"'
+++ echo :help
+...
+++ unprivileged /tmp/buildpacks/custom/bin/detect /tmp/build
+++ setuidgid u33467 /tmp/buildpacks/custom/bin/detect /tmp/build
+++ true
++ selected_name=
++ [[ -n /tmp/buildpacks/custom ]]
++ [[ -n '' ]]
++ title 'Unable to select a buildpack'
+----->' Unable to select a buildpack
++ exit 1
+```
 
 ## Contributing
 

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -76,10 +76,10 @@ buildpack-execute() {
 
 		IFS='#' read url commit <<< "$BUILDPACK_URL"
 		buildpack-install "$url" "$commit" custom &> /dev/null
-		
+
 		chown -R "$unprivileged_user:$unprivileged_group" "$buildpack_path/custom"
 
-		selected_name="$(unprivileged $selected_path/bin/detect $build_path)"
+		selected_name="$(unprivileged $selected_path/bin/detect $build_path || true)"
 	else
 		# force heroku-buildpack-multi to detect first if exists
 		if ls "$buildpack_path/heroku-buildpack-multi" > /dev/null 2>&1; then
@@ -95,7 +95,7 @@ buildpack-execute() {
 			done
 		fi
 	fi
-	if [[ "$selected_path" ]]; then
+	if [[ "$selected_path" ]] && [[ "$selected_name" ]]; then
 		title "$selected_name app detected"
 	else
 		title "Unable to select a buildpack"


### PR DESCRIPTION
commonly (in dokku at least) users complain that they cannot deploy when using a custom buildpack. see progrium/dokku#1433 for example and this issue is actually that the detect step fails silently when there is a custom buildpack defined.

this throws the standard `Unable to select a buildpack` message in this case

output:
```
-----> Fetching custom buildpack
-----> Unable to select a buildpack
```