### PR TITLE
attempting to make build more stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ BUILD_TAG ?= dev
 build:
 	cat buildpacks/*/buildpack* | sed 'N;s/\n/ /' > include/buildpacks.txt
 	go-bindata include
-	mkdir -p build/linux  && GOOS=linux  go build -ldflags "-X main.Version $(VERSION)" -o build/linux/$(NAME)
-	mkdir -p build/darwin && GOOS=darwin go build -ldflags "-X main.Version $(VERSION)" -o build/darwin/$(NAME)
+	mkdir -p build/linux  && GOOS=linux  go build -a -ldflags "-X main.Version $(VERSION)" -o build/linux/$(NAME)
+	mkdir -p build/darwin && GOOS=darwin go build -a -ldflags "-X main.Version $(VERSION)" -o build/darwin/$(NAME)
 ifeq ($(CIRCLECI),true)
 	docker build -t $(IMAGE_NAME):$(BUILD_TAG) .
 else


### PR DESCRIPTION
adds `-a force rebuild of packages that are already up to date`
since circleci upgraded to Go 1.5, go build sometimes pukes like the following

```
./herokuish.go:9: import /home/ubuntu/.go_workspace/pkg/linux_amd64/github.com/progrium/go-basher.a: object is [linux amd64 go1.5.1 X:none] expected [linux amd64 go1.4 X:precisestack]
```