### PR TITLE
implement heroku-like buildpack detect order and output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,17 @@ VERSION ?= 0.3.13
 IMAGE_NAME ?= $(NAME)
 BUILD_TAG ?= dev
 
+BUILDPACK_ORDER := multi ruby nodejs clojure python java gradle grails scala play php go erlang static emberjs
+SHELL := /bin/bash
+
 build:
-	cat buildpacks/*/buildpack* | sed 'N;s/\n/ /' | sort > include/buildpacks.txt
+	@count=0; \
+	for i in $(BUILDPACK_ORDER); do \
+		bp_count=$$(printf '%02d' $$count) ; \
+		echo -n "$${bp_count}_buildpack-$$i "; \
+		cat buildpacks/*-$$i/buildpack* | sed 'N;s/\n/ /'; \
+		count=$$((count + 1)) ; \
+	done > include/buildpacks.txt
 	go-bindata include
 	mkdir -p build/linux  && GOOS=linux  go build -a -ldflags "-X main.Version=$(VERSION)" -o build/linux/$(NAME)
 	mkdir -p build/darwin && GOOS=darwin go build -a -ldflags "-X main.Version=$(VERSION)" -o build/darwin/$(NAME)

--- a/buildpacks/buildpack-emberjs/tests/emberjs/.env
+++ b/buildpacks/buildpack-emberjs/tests/emberjs/.env
@@ -1,0 +1,1 @@
+export BUILDPACK_URL=https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz

--- a/buildpacks/test
+++ b/buildpacks/test
@@ -12,13 +12,15 @@ app-test() {
 
 # runs the generic app test
 run-test() {
+  [[ "$TRACE" ]] && set -x
   declare app="$1"
   local buildpack="buildpack-${1%%-*}"
   cd "$(dirname $BASH_SOURCE)"
   local app_path="$PWD/$buildpack/tests/$app"
   cd - &> /dev/null
 	[[ "$CI" ]] || rmflag="--rm"
-	docker run $rmflag -v "$app_path:/tmp/app" herokuish:dev /bin/herokuish test / "$app"
+  [[ "$TRACE" ]] && debug_flag="-e TRACE=true"
+  docker run $rmflag $debug_flag -v "$app_path:/tmp/app" herokuish:dev /bin/herokuish test / "$app"
 }
 
 main() {


### PR DESCRIPTION
Implements new detect order based on [Heroku](https://devcenter.heroku.com/articles/buildpacks#officially-supported-buildpacks).

```
multi
ruby
nodejs
clojure
python
java
gradle
grails
scala
play
php
go
erlang
static
emberjs
```

New output example:
```
-----> Warning: Multiple default buildpacks reported the ability to handle this app. The first buildpack in the list below will be used.
       Detected buildpacks: multi ruby nodejs python
-----> Multipack app detected
```

closes #133