### PR TITLE
Don't print .release file during build

### DIFF
--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -137,7 +137,6 @@ buildpack-execute() {
 		unprivileged "$selected_path/bin/release" "$build_path" "$cache_path" > "$build_path/.release"
 	fi
 	if [[ -f "$build_path/.release" ]]; then
-		cat "$build_path/.release"
 		config_vars="$(cat $build_path/.release | yaml-get config_vars)"
 		if [[ "$config_vars" ]]; then
 			mkdir -p $build_path/.profile.d


### PR DESCRIPTION
Printing this file differs from the Heroku deploy behavior and could potentially leak secret config variables.

My specific situation is that I have a Rails app with publicly viewable source and a continuous deployment setup. When the CI server deploys the app after a successful build, the contents of this file are included in its output (which is also publicly viewable). For a Rails app, this file includes `SECRET_KEY_BASE` which is used to secure sessions.