### PR TITLE
bugfix: curl may fail to fetch not quoted url if behind proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM heroku/cedar:14
-RUN curl https://github.com/gliderlabs/herokuish/releases/download/v0.3.27/herokuish_0.3.27_linux_x86_64.tgz \
+RUN curl "https://github.com/gliderlabs/herokuish/releases/download/v0.3.27/herokuish_0.3.27_linux_x86_64.tgz" \
 		--silent -L | tar -xzC /bin
 RUN /bin/herokuish buildpack install \
 	&& ln -s /bin/herokuish /build \


### PR DESCRIPTION
When http_proxy and https_proxy env vars are defined curl may fail to download a resource. Check these issues:
- https://github.com/dokku/dokku/issues/2181
- https://github.com/dokku/dokku/issues/1875