### PR TITLE
[build] fix old .env parsing to handle quotes and escapes better

### DIFF
--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -3,18 +3,18 @@ _envfile-parse() {
     declare desc="Parse input into shell export commands"
     local key
     local value
-    while read line || [[ -n "$line" ]]; do
+    while read -r line || [[ -n "$line" ]]; do
         [[ "$line" =~ ^#.* ]] && continue
         [[ "$line" =~ ^$ ]] && continue
         key=${line%%=*}
         key=${key#*export }
-        value=${line#*=}
+        value="${line#*=}"
         case "$value" in
             \'*|\"*)
-                value=${value}
+                value="${value}"
                 ;;
             *)
-                value=\"${value}\"
+                value=\""${value}"\"
                 ;;
         esac
         echo "export ${key}=${value}"

--- a/tests/unit/fixtures/complicated_envfile
+++ b/tests/unit/fixtures/complicated_envfile
@@ -1,0 +1,2 @@
+foo='Hello'$'\n'' '\''world'\'' '
+bar='te'\''st'

--- a/tests/unit/tests.sh
+++ b/tests/unit/tests.sh
@@ -1,0 +1,17 @@
+T_envfile-parse(){
+    source "$(dirname $BASH_SOURCE)/../../include/buildpack.bash"
+    local fixture_filename="$(dirname $BASH_SOURCE)/fixtures/complicated_envfile"
+    local foo_expected='Hello'$'\n'' '\''world'\'' '
+    local bar_expected='te'\''st'
+    eval "$(cat "$fixture_filename" | _envfile-parse)"
+
+    if [[ ! $foo_expected == $foo ]]; then
+        echo "Expected foo = $foo_expected got: $foo"
+        return 1
+    fi
+
+    if [[ ! $bar_expected == $bar ]]; then
+        echo "Expected bar = $bar_expected got: $bar"
+        return 2
+    fi
+}


### PR DESCRIPTION
Backslash escapes were getting interpreted by `read` and there were some instances of bare variable usage. There are likely still issues here but for two important cases it now works:
* `'lineone'$'\n''linetwo'`
* `'something'\''else'`

This lets newlines and embedded single quotes be part of the build environment and is part of the resolution to: https://github.com/dokku/dokku/issues/1262

Should I flesh-out, remove, or leave the 'test' alone? I made it as part of resolving this issue and it felt dirty to throw it out. On the other hand it's pretty underwhelming. I can make some bats tests if you'd like.