### PR TITLE
move base image to heroku16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM heroku/heroku:16
 RUN curl "https://github.com/gliderlabs/herokuish/releases/download/v0.3.32/herokuish_0.3.32_linux_x86_64.tgz" \
 		--silent -L | tar -xzC /bin
-RUN ln -s /bin/herokuish /build \
+RUN /bin/herokuish buildpack install \
+	&& ln -s /bin/herokuish /build \
 	&& ln -s /bin/herokuish /start \
 	&& ln -s /bin/herokuish /exec
 COPY include/default_user.bash /tmp/default_user.bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN ln -s /bin/herokuish /build \
 	&& ln -s /bin/herokuish /exec
 COPY include/default_user.bash /tmp/default_user.bash
 RUN bash /tmp/default_user.bash && rm -f /tmp/default_user.bash
-RUN apt-get update && apt-get install -y daemontools
+RUN apt-get update && apt-get install -y daemontools ruby-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM heroku/heroku:16
+RUN apt-get update -qq && apt-get install -yy -q daemontools ruby-dev
 RUN curl "https://github.com/gliderlabs/herokuish/releases/download/v0.3.32/herokuish_0.3.32_linux_x86_64.tgz" \
 		--silent -L | tar -xzC /bin
 RUN /bin/herokuish buildpack install \
@@ -7,4 +8,4 @@ RUN /bin/herokuish buildpack install \
 	&& ln -s /bin/herokuish /exec
 COPY include/default_user.bash /tmp/default_user.bash
 RUN bash /tmp/default_user.bash && rm -f /tmp/default_user.bash
-RUN apt-get update && apt-get install -y daemontools ruby-dev
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM heroku/cedar:14
+FROM heroku/heroku:16
 RUN curl "https://github.com/gliderlabs/herokuish/releases/download/v0.3.32/herokuish_0.3.32_linux_x86_64.tgz" \
 		--silent -L | tar -xzC /bin
-RUN /bin/herokuish buildpack install \
-	&& ln -s /bin/herokuish /build \
+RUN ln -s /bin/herokuish /build \
 	&& ln -s /bin/herokuish /start \
 	&& ln -s /bin/herokuish /exec
 COPY include/default_user.bash /tmp/default_user.bash
 RUN bash /tmp/default_user.bash && rm -f /tmp/default_user.bash
+RUN apt-get update && apt-get install -y daemontools


### PR DESCRIPTION
1. move base image to heroku16
2. do not install buildpacks, use custom buildpack for specific language not all of them.
3. install daemontools for missing setuidgid command