### PR TITLE
Use the official docker install script for Dockerfile.build

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,2 +1,2 @@
 FROM golang:1.8.3
-RUN curl -s -o - https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/local/bin/docker && chmod +x /usr/local/bin/docker
+RUN curl -sSL https://get.docker.com | sh


### PR DESCRIPTION
This PR is a one-liner that updates how docker is provisioned in Dockerfile.build

Using the https://get.docker.com script allows us to drop the explicit reference to `x86_64` and be more architecture agnostic.

Motivation: Docker recently (https://blog.docker.com/2017/09/docker-official-images-now-multi-platform/) made its official images multi-platform which brings us one step closer to making herokuish and (my eventual goal) dokku runnable on ARM architectures, (in my case the Raspberry Pi)

![image](https://user-images.githubusercontent.com/1246970/31848375-4ba109de-b5e6-11e7-9d32-e780a6f44d39.png)
