### PR TITLE
Only exclude the root `.git` folder

### DIFF
--- a/include/slug.bash
+++ b/include/slug.bash
@@ -30,7 +30,7 @@ slug-generate() {
 	# slugignore_option may be empty
 	# shellcheck disable=SC2086
 	tar "$compress_option" $slugignore_option \
-		--exclude='.git' \
+		--exclude='./.git' \
 		-C "$app_path" \
 		-cf "$slug_path" \
     	.


### PR DESCRIPTION
The current slug generation function excludes all `.git` folders in the `$app_path`. This changes it to ignore the root `.git` folder, but not others that may exist.

In my case, this caused a problem with elixir apps which have git dependencies. Elixir checks that these dependencies have a `.git` folder present to determine if they are available or not. When they are excluded from the slug, running the elixir app complains about missing dependencies.

In any case, I think we want to ignore the root `.git` folder to keep the slug size small, but I think including `.git` folders in sub-directories is probably not too harmful. What do you think?