### PR TITLE
upgrade golang to 1.11.2 for fixed debian jessie not found issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 ### Changed
+- update golang to 1.11.2 for docker build
 
 ## [0.4.5] - 2018-10-26
 ### Changed

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.8.3
+FROM golang:1.11.2
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
https://github.com/gliderlabs/herokuish/issues/398

Check the docker-hub site
https://hub.docker.com/_/golang/ 