### PR TITLE
Go modules + custom BASH_BIN support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
           tests=$(circleci tests glob buildpacks/*/tests/*/test.sh | circleci tests split --split-by=timings | xargs)
           echo "executing tests: $tests"
           basht $tests
+      - store_artifacts:
+          path: build
+          destination: build
       - deploy:
           name: release
           command: |

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.11.2
+FROM golang:1.12.0
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -15,3 +15,5 @@ RUN apt-get update -qq \
    "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"
 RUN apt-get update -qq \
  && apt-get install -qq -y --force-yes docker-ce=17.12.0~ce-0~debian
+
+WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build-in-docker:
 	docker build --rm -f Dockerfile.build -t $(NAME)-build .
 	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro \
 		-v /var/lib/docker:/var/lib/docker \
-		-v ${PWD}:/go/src/github.com/gliderlabs/herokuish -w /go/src/github.com/gliderlabs/herokuish \
+		-v ${PWD}:/src/github.com/gliderlabs/herokuish -w /src/github.com/gliderlabs/herokuish \
 		-e IMAGE_NAME=$(IMAGE_NAME) -e BUILD_TAG=$(BUILD_TAG) -e VERSION=master \
 		$(NAME)-build make -e deps build
 	docker rmi $(NAME)-build || true

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module herokuish
+
+go 1.12
+
+require (
+	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/progrium/go-basher v0.0.0-20170201215011-ad5de635edd1
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
+github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/progrium/go-basher v0.0.0-20170201215011-ad5de635edd1 h1:BC5AL7yOCJKQ1bGiBoJwdyHHBGSLQIdbU+l/E11j0HA=
+github.com/progrium/go-basher v0.0.0-20170201215011-ad5de635edd1/go.mod h1:Oiy7jZEU1mm+gI1dt5MKYwxptmD37q8/UupxnwhMHtI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/herokuish.go
+++ b/herokuish.go
@@ -78,16 +78,23 @@ func AssetCat(args []string) {
 
 func main() {
 	os.Setenv("HEROKUISH_VERSION", Version)
-	basher.Application(map[string]func([]string){
+	funcs := map[string]func([]string){
 		"yaml-keys": YamlKeys,
 		"yaml-get":  YamlGet,
 		"asset-cat": AssetCat,
-	}, []string{
+	}
+	scripts := []string{
 		"include/herokuish.bash",
 		"include/fn.bash",
 		"include/cmd.bash",
 		"include/buildpack.bash",
 		"include/procfile.bash",
 		"include/slug.bash",
-	}, Asset, true)
+	}
+
+	if os.Getenv("BASH_BIN") == "" {
+		basher.Application(funcs, scripts, Asset, true)
+	} else {
+		basher.ApplicationWithPath(funcs, scripts, Asset, true, os.Getenv("BASH_BIN"))
+	}
 }


### PR DESCRIPTION
This PR:

- switches to go modules
- updates go-bindata
- allows using another bash - and not the embedded one - by setting the `BASH_BIN` environment variable
- stores built artifacts so we can inspect them later (useful as we don't always release herokuish)