### PR TITLE
Correct outdated dependencies

### DIFF
--- a/buildpacks/buildpack-multi/tests/multi/requirements.txt
+++ b/buildpacks/buildpack-multi/tests/multi/requirements.txt
@@ -1,3 +1,3 @@
 Flask==0.12.2
-Jinja2==2.6
-gunicorn==0.17.2
+Jinja2==2.10.1
+gunicorn==19.5.0

--- a/buildpacks/buildpack-python/tests/python-django/requirements.txt
+++ b/buildpacks/buildpack-python/tests/python-django/requirements.txt
@@ -1,2 +1,2 @@
-Django==1.11.2
-gunicorn==18.0
+Django==1.11.21
+gunicorn==19.5.0

--- a/buildpacks/buildpack-python/tests/python-flask/requirements.txt
+++ b/buildpacks/buildpack-python/tests/python-flask/requirements.txt
@@ -1,3 +1,3 @@
 Flask==0.12.2
-Jinja2==2.6
-gunicorn==0.17.2
+Jinja2==2.10.1
+gunicorn==19.5.0


### PR DESCRIPTION
While the code is not in use, the outdated dependencies surface warnings in the Github UI.