### PR TITLE
Only copy from app import path to app path when building

### DIFF
--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -145,11 +145,11 @@ buildpack-list() {
 }
 
 buildpack-setup() {
-  # $import_path is defined in outer scope
-  # shellcheck disable=SC2154
-  if [[ -d "$import_path" ]] && [[ -n "$(ls -A "$import_path")" ]]; then
-    rm -rf "$app_path" && cp -r "$import_path" "$app_path"
-  fi
+	# $import_path is defined in outer scope
+	# shellcheck disable=SC2154
+	if [[ -d "$import_path" ]] && [[ -n "$(ls -A "$import_path")" ]]; then
+		rm -rf "$app_path" && cp -r "$import_path" "$app_path"
+	fi
 
   # Buildpack expectations
   # app_path defined in outer scope

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -145,11 +145,11 @@ buildpack-list() {
 }
 
 buildpack-setup() {
-	# $import_path is defined in outer scope
-	# shellcheck disable=SC2154
-	if [[ -d "$import_path" ]] && [[ -n "$(ls -A "$import_path")" ]]; then
-		rm -rf "$app_path" && cp -r "$import_path" "$app_path"
-	fi
+  # $import_path is defined in outer scope
+  # shellcheck disable=SC2154
+  if [[ -d "$import_path" ]] && [[ -n "$(ls -A "$import_path")" ]]; then
+    rm -rf "$app_path" && cp -r "$import_path" "$app_path"
+  fi
 
   # Buildpack expectations
   # app_path defined in outer scope

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -145,6 +145,7 @@ buildpack-list() {
 }
 
 buildpack-setup() {
+  # $import_path is defined in outer scope
   # shellcheck disable=SC2154
   if [[ -d "$import_path" ]] && [[ -n "$(ls -A "$import_path")" ]]; then
     rm -rf "$app_path" && cp -r "$import_path" "$app_path"

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -145,6 +145,11 @@ buildpack-list() {
 }
 
 buildpack-setup() {
+  # shellcheck disable=SC2154
+  if [[ -d "$import_path" ]] && [[ -n "$(ls -A "$import_path")" ]]; then
+    rm -rf "$app_path" && cp -r "$import_path" "$app_path"
+  fi
+
   # Buildpack expectations
   # app_path defined in outer scope
   # shellcheck disable=SC2154

--- a/include/herokuish.bash
+++ b/include/herokuish.bash
@@ -123,10 +123,6 @@ main() {
   set -eo pipefail
   [[ "$TRACE" ]] && set -x
 
-  if [[ -d "$import_path" ]] && [[ -n "$(ls -A "$import_path")" ]]; then
-    rm -rf "$app_path" && cp -r "$import_path" "$app_path"
-  fi
-
   cmd-export paths
   cmd-export version
   cmd-export herokuish-test test


### PR DESCRIPTION
This PR fixes #402 (slug generate gzips from /tmp/app, when it should gzip from /app) and #321 (Cannot execute any Procfile commands) and fixed the issue mentioned in the blog post ["Running Herokuish apps in Docker"](https://knazarov.com/posts/herokuish_apps_in_docker/).

Currently every time herokuish is run the app import path (e.g. /tmp/app) is copied over to the app path (e.g. /app) if the import path exists and has files in it.

This PR changes this so that the copy from the import path to the app path is only done on running `herokuish buildpack build` or `herokuish buildpack test` [as suggested by @matthewmueller in #402](https://github.com/gliderlabs/herokuish/issues/402#issuecomment-449701095).

This means that you can now run `buildpack build` immediately followed by `procfile start` within the same container and things will work.

I can see at least two different ways that people were working around this issue before:
1. Mount the application volume in the app directory (/app) rather than the import app directory (/tmp/app) [as seen in Dokku](https://github.com/gliderlabs/herokuish/issues/321#issuecomment-379480575). This has the disadvantage that build artifacts get written into the same directory as the source code (of course you might want this, you might not).
2. By [using the recommended flow as outlined by @michaelshobbs](https://github.com/gliderlabs/herokuish/issues/321#issuecomment-379899875), you create a docker image from the result of running `buildpack build` and then running a container from that image which doesn't have a volume mounted at /tmp/app and so the contents of /app is not overwritten.

This PR should not break those workarounds.