### PR TITLE
feat: allow imagemagick to properly update with custom config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -qq \
  && apt-get install -qq -y daemontools \
- && apt-get -qq -y \
+ && cp /etc/ImageMagick-6/policy.xml /etc/ImageMagick-6/policy.xml.custom \
+ && apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew \
     --allow-downgrades \
     --allow-remove-essential \
     --allow-change-held-packages \
     dist-upgrade \
+ && mv /etc/ImageMagick-6/policy.xml.custom /etc/ImageMagick-6/policy.xml \
  && apt-get clean \
  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /var/tmp/*
 RUN curl "https://github.com/gliderlabs/herokuish/releases/download/v0.5.3/herokuish_0.5.3_linux_x86_64.tgz" \


### PR DESCRIPTION
The custom configuration comes from heroku, and as such we need to allow dpkg to pull in the new config but also move the custom config back as desired.