### PR TITLE
Automate package release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,5 +29,5 @@ jobs:
           name: release
           command: |
             if [ "${CIRCLE_BRANCH}" == "release" ]; then
-              make release
+              make release release-packagecloud
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,6 @@ jobs:
           case $CIRCLE_NODE_INDEX in 0) make shellcheck;; esac
       - run: |
           case $CIRCLE_NODE_INDEX in 0) make lint;; esac
-      - run:
-         name: Set ruby version to 2.3.4
-         command: |
-          rvm install 2.3.4
-          echo . $(rvm 2.3.4 do rvm env --path) >> $BASH_ENV
       - run: |
           make circleci
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,15 @@ jobs:
           case $CIRCLE_NODE_INDEX in 0) make shellcheck;; esac
       - run: |
           case $CIRCLE_NODE_INDEX in 0) make lint;; esac
+      - run:
+         name: Set ruby version to 2.3.4
+         command: |
+          rvm install 2.3.4
+          echo . $(rvm 2.3.4 do rvm env --path) >> $BASH_ENV
       - run: |
           make circleci
       - run: |
-          make deps
+          make deps fpm
       - run: |
           make build
       - run: |

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ trim_trailing_whitespace = true
 [*.go]
 indent_style = tab
 indent_size = 4
+
+[contrib/post-install]
+indent_size = 2
+indent_style = space

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ BUILD_TAG ?= dev
 
 BUILDPACK_ORDER := multi ruby nodejs clojure python java gradle scala play php go static
 SHELL := /bin/bash
+SYSTEM := $(shell sh -c 'uname -s 2>/dev/null')
 
 shellcheck:
 ifneq ($(shell shellcheck --version > /dev/null 2>&1 ; echo $$?),0)
@@ -97,8 +98,10 @@ deps:
 	go get -u github.com/progrium/gh-release/...
 	go get -u github.com/progrium/basht/...
 	go get || true
+ifeq ($(SYSTEM),Linux)
 	apt-get update && apt-get -y install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
 	command -v fpm >/dev/null || sudo gem install fpm --no-ri --no-rdoc
+endif
 
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 NAME = herokuish
+DESCRIPTION = 'Herokuish uses Docker and Buildpacks to build applications like Heroku'
 HARDWARE = $(shell uname -m)
 VERSION ?= 0.5.15
 IMAGE_NAME ?= $(NAME)
@@ -33,15 +34,57 @@ ifeq ($(CIRCLECI),true)
 else
 	docker build -f Dockerfile.dev -t $(IMAGE_NAME):$(BUILD_TAG) .
 endif
+	$(MAKE) build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
+	$(MAKE) build/deb/$(NAME)_$(VERSION)_amd64.deb
 
-build-in-docker:
-	docker build --rm -f Dockerfile.build -t $(NAME)-build .
-	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro \
-		-v /var/lib/docker:/var/lib/docker \
-		-v ${PWD}:/src/github.com/gliderlabs/herokuish -w /src/github.com/gliderlabs/herokuish \
-		-e IMAGE_NAME=$(IMAGE_NAME) -e BUILD_TAG=$(BUILD_TAG) -e VERSION=master \
-		$(NAME)-build make -e deps build
-	docker rmi $(NAME)-build || true
+build/deb:
+	mkdir -p build/deb
+
+build/deb/$(NAME)_$(VERSION)_amd64.deb: build/deb
+	echo $(VERSION) > /tmp/$(NAME)-VERSION
+	fpm \
+		--after-install contrib/post-install \
+		--architecture amd64 \
+		--category utils \
+		--deb-pre-depends 'docker-engine-cs (>= 1.13.0) | docker-engine (>= 1.13.0) | docker-io (>= 1.13.0) | docker.io (>= 1.13.0) | docker-ce (>= 1.13.0) | docker-ee (>= 1.13.0) | moby-engine' \
+		--deb-pre-depends sudo \
+		--description $(DESCRIPTION) \
+		--input-type dir \
+		--license 'MIT License' \
+		--name $(NAME) \
+		--output-type deb \
+		--package build/deb/$(NAME)_$(VERSION)_amd64.deb \
+		--url "https://github.com/gliderlabs/$(NAME)" \
+		--vendor "" \
+		--version $(VERSION) \
+		--verbose \
+		/tmp/$(NAME)-VERSION=/var/lib/herokuish/VERSION \
+		LICENSE=/usr/share/doc/$(NAME)/copyright
+
+build/rpm:
+	mkdir -p build/rpm
+
+build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm: build/rpm
+	echo $(VERSION) > /tmp/$(NAME)-VERSION
+	fpm \
+		--after-install contrib/post-install \
+		--architecture x86_64 \
+		--category utils \
+		--depends '/usr/bin/docker' \
+		--depends 'sudo' \
+		--description $(DESCRIPTION) \
+		--input-type dir \
+		--license 'MIT License' \
+		--name $(NAME) \
+		--output-type rpm \
+		--package build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm \
+		--url "https://github.com/gliderlabs/$(NAME)" \
+		--vendor "" \
+		--version $(VERSION) \
+		--verbose \
+		/tmp/$(NAME)-VERSION=/var/lib/herokuish/VERSION \
+		LICENSE=/usr/share/doc/$(NAME)/copyright
+
 
 clean:
 	rm -rf build/*
@@ -54,6 +97,9 @@ deps:
 	go get -u github.com/progrium/gh-release/...
 	go get -u github.com/progrium/basht/...
 	go get || true
+	apt-get update && apt-get -y install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
+	command -v fpm >/dev/null || sudo gem install fpm --no-ri --no-rdoc
+
 
 test:
 	basht tests/*/tests.sh
@@ -73,10 +119,26 @@ lint:
 
 release: build
 	rm -rf release && mkdir release
+	cp build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm release/$(NAME)-$(VERSION)-1.x86_64.rpm
+	cp build/deb/$(NAME)_$(VERSION)_amd64.deb release/$(NAME)_$(VERSION)_amd64.deb
 	tar -zcf release/$(NAME)_$(VERSION)_linux_$(HARDWARE).tgz -C build/linux $(NAME)
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_$(HARDWARE).tgz -C build/darwin $(NAME)
 	gh-release create gliderlabs/$(NAME) $(VERSION) \
 		$(shell git rev-parse --abbrev-ref HEAD) v$(VERSION)
+
+release-packagecloud:
+	@$(MAKE) release-packagecloud-deb
+	@$(MAKE) release-packagecloud-rpm
+
+release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/xenial  build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/bionic  build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal   build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/stretch build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/buster  build/deb/$(NAME)_$(VERSION)_amd64.deb
+
+release-packagecloud-rpm: build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/el/7           build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
 
 bumpup:
 	for i in $(BUILDPACK_ORDER); do \
@@ -94,4 +156,4 @@ bumpup:
 		fi ; \
 	done
 
-.PHONY: build
+.PHONY: build build/deb/$(NAME)_$(VERSION)_amd64.deb build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ endif
 fpm:
 ifeq ($(SYSTEM),Linux)
 	sudo apt-get update && sudo apt-get -y install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
-	command -v fpm >/dev/null || sudo gem install fpm ffi:1.9.25 --no-ri --no-rdoc
+	command -v fpm >/dev/null || sudo gem install ffi -v 1.9.25 --no-ri --no-rdoc
+	command -v fpm >/dev/null || sudo gem install fpm --no-ri --no-rdoc
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ deps:
 	go get -u github.com/progrium/basht/...
 	go get || true
 ifeq ($(SYSTEM),Linux)
-	sudo apt-get update && sudo apt-get -y install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
+	sudo apt-get update && sudo apt-get -y install gcc git build-essential wget ruby-full lintian rpm help2man man-db
 	command -v fpm >/dev/null || sudo gem install fpm --no-ri --no-rdoc
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ deps:
 	go get -u github.com/progrium/basht/...
 	go get || true
 ifeq ($(SYSTEM),Linux)
-	apt-get update && apt-get -y install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
+	sudo apt-get update && sudo apt-get -y install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
 	command -v fpm >/dev/null || sudo gem install fpm --no-ri --no-rdoc
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,11 @@ endif
 endif
 
 fpm:
+ifeq ($(SYSTEM),Linux)
+	sudo apt-get update && sudo apt-get -y install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
 	command -v fpm >/dev/null || sudo gem install fpm --no-ri --no-rdoc
+endif
+
 
 build:
 	@count=0; \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 fpm:
 ifeq ($(SYSTEM),Linux)
 	sudo apt-get update && sudo apt-get -y install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
-	command -v fpm >/dev/null || sudo gem install fpm --no-ri --no-rdoc
+	command -v fpm >/dev/null || sudo gem install fpm ffi:1.9.25 --no-ri --no-rdoc
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ endif
 fpm:
 ifeq ($(SYSTEM),Linux)
 	sudo apt-get update && sudo apt-get -y install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
-	command -v fpm >/dev/null || sudo gem install ffi -v 1.9.25 --no-ri --no-rdoc
-	command -v fpm >/dev/null || sudo gem install fpm --no-ri --no-rdoc
+	command -v fpm >/dev/null || gem install fpm --no-ri --no-rdoc
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ else
 endif
 endif
 
+fpm:
+	command -v fpm >/dev/null || sudo gem install fpm --no-ri --no-rdoc
+
 build:
 	@count=0; \
 	for i in $(BUILDPACK_ORDER); do \
@@ -98,10 +101,6 @@ deps:
 	go get -u github.com/progrium/gh-release/...
 	go get -u github.com/progrium/basht/...
 	go get || true
-ifeq ($(SYSTEM),Linux)
-	sudo apt-get update && sudo apt-get -y install gcc git build-essential wget ruby-full lintian rpm help2man man-db
-	command -v fpm >/dev/null || sudo gem install fpm --no-ri --no-rdoc
-endif
 
 
 test:

--- a/contrib/post-install
+++ b/contrib/post-install
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if which systemctl > /dev/null; then
+  echo "Starting docker"
+  systemctl start docker
+  sleep 5
+fi
+
+echo 'Importing herokuish into docker (around 5 minutes)'
+if [[ -n "$http_proxy" ]] || [[ -n "$https_proxy" ]]; then
+  echo "See the docker pull docs for proxy configuration";
+fi
+
+VERSION=$(cat /var/lib/herokuish/VERSION)
+
+sudo docker pull "gliderlabs/herokuish:v${VERSION}"
+sudo docker tag "gliderlabs/herokuish:v${VERSION}" gliderlabs/herokuish:latest


### PR DESCRIPTION
This change should hopefully automatically release deb/rpm packages to packagecloud. The deb/rpm will also be attached to the github release.