### PR TITLE
fix: change directories after HOME is setup

### DIFF
--- a/buildpacks/buildpack-php/tests/php/Procfile
+++ b/buildpacks/buildpack-php/tests/php/Procfile
@@ -1,1 +1,1 @@
-web: $(composer config bin-dir)/heroku-php-nginx -C nginx.conf public/
+web: heroku-php-nginx -C nginx.conf public/

--- a/include/procfile.bash
+++ b/include/procfile.bash
@@ -49,9 +49,9 @@ procfile-exec() {
 	declare desc="Run as unprivileged user with Heroku-like env"
 	[[ "$USER" ]] || detect-unprivileged
 	procfile-setup-home
+	cd "$app_path" || return 1
 	procfile-load-env
 	procfile-load-profile
-	cd "$app_path" || return 1
 	# unprivileged_user is defined in outer scope
 	# shellcheck disable=SC2154,SC2046
 	if [[ "$HEROKUISH_SETUIDGUID" == "false" ]]; then


### PR DESCRIPTION
Some `profile.d` files may end up referencing files that are in `$HOME` via relative paths. As this functionality works on Heroku, we should attempt to emulate it as best we can.

Refs heroku/heroku-buildpack-php#450