### PR TITLE
feat: add ability to build heroku-20 based images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM heroku/heroku:18-build
+ARG STACK_VERSION=18
+FROM heroku/heroku:$STACK_VERSION-build
+ARG STACK_VERSION
 
+ENV STACK=heroku-$STACK_VERSION
 ENV DEBIAN_FRONTEND noninteractive
+LABEL com.gliderlabs.herokuish/stack=$STACK
 
 RUN apt-get update -qq \
  && apt-get install -qq -y daemontools \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,10 @@
-FROM heroku/heroku:18-build
+ARG STACK_VERSION=18
+FROM heroku/heroku:$STACK_VERSION-build
+ARG STACK_VERSION
 
+ENV STACK=heroku-$STACK_VERSION
 ENV DEBIAN_FRONTEND noninteractive
+LABEL com.gliderlabs.herokuish/stack=$STACK
 
 RUN apt-get update -qq \
  && apt-get install -qq -y daemontools \

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,10 @@ build:
 	mkdir -p build/darwin && GOOS=darwin go build -a -ldflags "-X main.Version=$(VERSION)" -o build/darwin/$(NAME)
 ifeq ($(CIRCLECI),true)
 	docker build -t $(IMAGE_NAME):$(BUILD_TAG) .
+	docker build -t $(IMAGE_NAME):$(BUILD_TAG)-20 --build-arg STACK_VERSION=20 .
 else
 	docker build -f Dockerfile.dev -t $(IMAGE_NAME):$(BUILD_TAG) .
+	docker build -f Dockerfile.dev -t $(IMAGE_NAME):$(BUILD_TAG)-20 --build-arg STACK_VERSION=20 .
 endif
 	$(MAKE) build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
 	$(MAKE) build/deb/$(NAME)_$(VERSION)_amd64.deb
@@ -108,6 +110,7 @@ clean:
 
 deps:
 	docker pull heroku/heroku:18-build
+	docker pull heroku/heroku:20-build
 	go get -u github.com/jteeuwen/go-bindata/...
 	go get -u github.com/progrium/gh-release/...
 	go get -u github.com/progrium/basht/...

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A command line tool for emulating Heroku build and runtime tasks in containers.
 
 Herokuish is made for platform authors. The project consolidates and decouples Heroku compatibility logic (running buildpacks, parsing Procfile) and supporting workflow (importing/exporting slugs) from specific platform images like those in Dokku/Buildstep, Deis, Flynn, etc.
 
-The goal is to be the definitive, well maintained and heavily tested Heroku emulation utility shared by all. It is based on the [Cedar Heroku:18 system image](https://github.com/heroku/stack-images). Together they form a toolkit for achieving Heroku compatibility.
+The goal is to be the definitive, well maintained and heavily tested Heroku emulation utility shared by all. It is based on the [Heroku:18 and Heroku:20 system images](https://github.com/heroku/stack-images). Together they form a toolkit for achieving Heroku compatibility.
 
 Herokuish is a community project and is in no way affiliated with Heroku.
 


### PR DESCRIPTION
We still default to heroku-18, but this paves the way for building heroku-20 in tandem.