### PR TITLE
Publish all stacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,13 @@ jobs:
       - run: |
           echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
       - run: |
-          docker build -t $(IMAGE_NAME):$(BUILD_TAG)-18 --build-arg STACK_VERSION=18 .
+          docker build -t $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-18 --build-arg STACK_VERSION=18 .
       - run: |
-          docker build -t $(IMAGE_NAME):$(BUILD_TAG)-20 --build-arg STACK_VERSION=20 .
+          docker build -t $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-20 --build-arg STACK_VERSION=20 .
       - run: |
-          docker push $(IMAGE_NAME):$(BUILD_TAG)-18
+          docker push $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-18
       - run: |
-          docker push $(IMAGE_NAME):$(BUILD_TAG)-20
+          docker push $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-20
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,5 +57,7 @@ workflows:
     jobs:
       - docker-build:
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,3 +32,30 @@ jobs:
               export PACKAGECLOUD_REPOSITORY=dokku/dokku
               make release release-packagecloud
             fi
+  docker-build:
+    machine: true
+    working_directory: ~/gliderlabs/herokuish
+    steps:
+      - checkout
+      - run: |
+          echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      - run: |
+          docker build -t $(IMAGE_NAME):$(BUILD_TAG)-18 --build-arg STACK_VERSION=18 .
+      - run: |
+          docker build -t $(IMAGE_NAME):$(BUILD_TAG)-20 --build-arg STACK_VERSION=20 .
+      - run: |
+          docker push $(IMAGE_NAME):$(BUILD_TAG)-18
+      - run: |
+          docker push $(IMAGE_NAME):$(BUILD_TAG)-20
+
+workflows:
+  version: 2
+  untagged-build:
+    jobs:
+      - build
+  tagged-build:
+    jobs:
+      - docker-build:
+          filters:
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  workflow:
     machine: true
     working_directory: ~/gliderlabs/herokuish
     parallelism: 4
@@ -32,7 +32,7 @@ jobs:
               export PACKAGECLOUD_REPOSITORY=dokku/dokku
               make release release-packagecloud
             fi
-  docker-build:
+  release-workflow:
     machine: true
     working_directory: ~/gliderlabs/herokuish
     steps:
@@ -50,12 +50,12 @@ jobs:
 
 workflows:
   version: 2
-  untagged-build:
+  workflow:
     jobs:
-      - build
-  tagged-build:
+      - workflow
+  release-workflow:
     jobs:
-      - docker-build:
+      - release-workflow:
           filters:
             branches:
               ignore: /.*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN apt-get update -qq \
 RUN curl "https://github.com/gliderlabs/herokuish/releases/download/v0.5.22/herokuish_0.5.22_linux_x86_64.tgz" \
     --silent -L | tar -xzC /bin
 RUN /bin/herokuish buildpack install \
-  && ln -s /bin/herokuish /build \
-  && ln -s /bin/herokuish /start \
-  && ln -s /bin/herokuish /exec
+    && ln -s /bin/herokuish /build \
+    && ln -s /bin/herokuish /start \
+    && ln -s /bin/herokuish /exec
 COPY include/default_user.bash /tmp/default_user.bash
 RUN bash /tmp/default_user.bash && rm -f /tmp/default_user.bash

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,12 +8,20 @@ LABEL com.gliderlabs.herokuish/stack=$STACK
 
 RUN apt-get update -qq \
  && apt-get install -qq -y daemontools \
+ && cp /etc/ImageMagick-6/policy.xml /etc/ImageMagick-6/policy.xml.custom \
+ && apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew \
+    --allow-downgrades \
+    --allow-remove-essential \
+    --allow-change-held-packages \
+    dist-upgrade \
+ && mv /etc/ImageMagick-6/policy.xml.custom /etc/ImageMagick-6/policy.xml \
  && apt-get clean \
  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /var/tmp/*
 COPY ./build/linux/herokuish /bin/herokuish
+
 RUN /bin/herokuish buildpack install \
-	&& ln -s /bin/herokuish /build \
-	&& ln -s /bin/herokuish /start \
-	&& ln -s /bin/herokuish /exec
+    && ln -s /bin/herokuish /build \
+    && ln -s /bin/herokuish /start \
+    && ln -s /bin/herokuish /exec
 COPY include/default_user.bash /tmp/default_user.bash
 RUN bash /tmp/default_user.bash && rm -f /tmp/default_user.bash


### PR DESCRIPTION
This change will publish docker images for both heroku:18 and heroku:20 stacks when we make a release. A future release will also include both images in the packagecloud package.