### PR TITLE
Source .profile in app path root if exists

### DIFF
--- a/include/procfile.bash
+++ b/include/procfile.bash
@@ -109,6 +109,7 @@ procfile-load-profile() {
 		source "$file"
 	done
 	if [[ -s "$app_path/.profile" ]]; then
+		# shellcheck disable=SC1090
 		source "$app_path/.profile"
 	fi
 	shopt -u nullglob

--- a/include/procfile.bash
+++ b/include/procfile.bash
@@ -108,6 +108,9 @@ procfile-load-profile() {
 		# shellcheck disable=SC1090
 		source "$file"
 	done
+	if [[ -s "$app_path/.profile" ]]; then
+		source "$app_path/.profile"
+	fi
 	shopt -u nullglob
 	hash -r
 }


### PR DESCRIPTION
This matches Heroku behaviour to allow starting processes or execute commands that are not proc types