### PR TITLE
feat: drop non-buildpack related files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,13 @@ RUN curl "https://github.com/gliderlabs/herokuish/releases/download/v0.5.26/hero
 RUN /bin/herokuish buildpack install \
     && ln -s /bin/herokuish /build \
     && ln -s /bin/herokuish /start \
-    && ln -s /bin/herokuish /exec
+    && ln -s /bin/herokuish /exec \
+    && cd /tmp/buildpacks \
+    && rm -rf */.git \
+    && rm -rf */.github \
+    && rm -rf */.circleci \
+    && rm -rf */spec \
+    && rm -rf */test \
+    && rm -rf */tmp
 COPY include/default_user.bash /tmp/default_user.bash
 RUN bash /tmp/default_user.bash && rm -f /tmp/default_user.bash


### PR DESCRIPTION
These should be relatively safe to cleanup, but also ensure the buildpack directory is much smaller than before (4k files vs 800).