### PR TITLE
feat: Prepare permissions quicker for slower filesystems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,15 @@ RUN /bin/herokuish buildpack install \
     && ln -s /bin/herokuish /start \
     && ln -s /bin/herokuish /exec \
     && cd /tmp/buildpacks \
-    && rm -rf */.git \
-    && rm -rf */.github \
-    && rm -rf */.circleci \
-    && rm -rf */spec \
-    && rm -rf */test \
-    && rm -rf */tmp
+    && rm -rf \
+            */.git \
+            */.github \
+            */.circleci \
+            */changelogs \
+            */spec \
+            */support/build \
+            */builds \
+            */test \
+            */tmp
 COPY include/default_user.bash /tmp/default_user.bash
 RUN bash /tmp/default_user.bash && rm -f /tmp/default_user.bash

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -24,11 +24,15 @@ RUN /bin/herokuish buildpack install \
     && ln -s /bin/herokuish /start \
     && ln -s /bin/herokuish /exec \
     && cd /tmp/buildpacks \
-    && rm -rf */.git \
-    && rm -rf */.github \
-    && rm -rf */.circleci \
-    && rm -rf */spec \
-    && rm -rf */test \
-    && rm -rf */tmp
+    && rm -rf \
+            */.git \
+            */.github \
+            */.circleci \
+            */changelogs \
+            */spec \
+            */support/build \
+            */builds \
+            */test \
+            */tmp
 COPY include/default_user.bash /tmp/default_user.bash
 RUN bash /tmp/default_user.bash && rm -f /tmp/default_user.bash

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.12
 require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/progrium/go-basher v0.0.0-20170201215011-ad5de635edd1
+	github.com/progrium/go-basher v0.0.0-20190315062444-ad5de635edd1
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uia
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/progrium/go-basher v0.0.0-20170201215011-ad5de635edd1 h1:BC5AL7yOCJKQ1bGiBoJwdyHHBGSLQIdbU+l/E11j0HA=
-github.com/progrium/go-basher v0.0.0-20170201215011-ad5de635edd1/go.mod h1:Oiy7jZEU1mm+gI1dt5MKYwxptmD37q8/UupxnwhMHtI=
+github.com/progrium/go-basher v0.0.0-20190315062444-ad5de635edd1 h1:pNf4kIAZbE5uKZ1tZAEXOvDcO7+32PeMOlAl85E8UU4=
+github.com/progrium/go-basher v0.0.0-20190315062444-ad5de635edd1/go.mod h1:Oiy7jZEU1mm+gI1dt5MKYwxptmD37q8/UupxnwhMHtI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -161,13 +161,13 @@ buildpack-setup() {
 	# shellcheck disable=SC2154
 	chown -R "$unprivileged_user:$unprivileged_group" "$app_path"
 	# shellcheck disable=SC2154
-	find "$build_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -0 -r chown "$unprivileged_user:$unprivileged_group"
+	find "$build_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -P 0 -0 --no-run-if-empty chown --no-dereference "$unprivileged_user:$unprivileged_group"
 	# shellcheck disable=SC2154
-	find "$cache_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -0 -r chown "$unprivileged_user:$unprivileged_group"
+	find "$cache_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -P 0 -0 --no-run-if-empty chown --no-dereference "$unprivileged_user:$unprivileged_group"
 	# shellcheck disable=SC2154
-	find "$env_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -0 -r chown "$unprivileged_user:$unprivileged_group"
+	find "$env_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -P 0 -0 --no-run-if-empty chown --no-dereference "$unprivileged_user:$unprivileged_group"
 	# shellcheck disable=SC2154
-	find "$buildpack_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -0 -r chown "$unprivileged_user:$unprivileged_group"
+	find "$buildpack_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -P 0 -0 --no-run-if-empty chown --no-dereference "$unprivileged_user:$unprivileged_group"
 
 	# Useful settings / features
 	export CURL_CONNECT_TIMEOUT="30"

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -130,6 +130,8 @@ buildpack-install() {
 		chown -R root:root "$target_path"
 		chmod 755 "$target_path"
 	fi
+
+	find "$buildpack_path" \( \! -user "${unprivileged_user:-32767}" -o \! -group "${unprivileged_group:-32767}" \) -print0 | xargs -P 0 -0 --no-run-if-empty chown --no-dereference "${unprivileged_user:-32767}:${unprivileged_group:-32767}"
 }
 
 buildpack-list() {

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -155,14 +155,19 @@ buildpack-setup() {
 	# unprivileged_user defined in outer scope
 	# shellcheck disable=SC2154
 	usermod --home "$HOME" "$unprivileged_user" > /dev/null 2>&1
+
+	# Prepare permissions quicker for slower filesystems
 	# vars defined in outer scope
 	# shellcheck disable=SC2154
-	chown -R "$unprivileged_user:$unprivileged_group" \
-		"$app_path" \
-		"$build_path" \
-		"$cache_path" \
-		"$env_path" \
-		"$buildpack_path"
+	chown -R "$unprivileged_user:$unprivileged_group" "$app_path"
+	# shellcheck disable=SC2154
+	find "$build_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -0 -r chown "$unprivileged_user:$unprivileged_group"
+	# shellcheck disable=SC2154
+	find "$cache_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -0 -r chown "$unprivileged_user:$unprivileged_group"
+	# shellcheck disable=SC2154
+	find "$env_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -0 -r chown "$unprivileged_user:$unprivileged_group"
+	# shellcheck disable=SC2154
+	find "$buildpack_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -0 -r chown "$unprivileged_user:$unprivileged_group"
 
 	# Useful settings / features
 	export CURL_CONNECT_TIMEOUT="30"


### PR DESCRIPTION
Builds on top of #662 as we need to get rid of the symlinks in those directories because the golang one has a non-file symlink that breaks the find...

Refs #114