### PR TITLE
🔖 Improve Docker image tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,15 @@ jobs:
       - run: |
           echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
       - run: |
-          docker build -t $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-18 --build-arg STACK_VERSION=18 .
+          docker image build -t $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-18 -t $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:latest-18 --build-arg STACK_VERSION=18 .
       - run: |
-          docker build -t $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-20 --build-arg STACK_VERSION=20 .
+          docker image build -t $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-20 -t $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:latest-20 --build-arg STACK_VERSION=20 .
       - run: |
-          docker push $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-18
+          docker image push $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-18
+          docker image push $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:latest-18
       - run: |
-          docker push $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-20
+          docker image push $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-20
+          docker image push $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:latest-20
 
 workflows:
   version: 2


### PR DESCRIPTION
As previously discussed on Slack, this PR should introduce additional `latest-18` and `latest-20` tags so that the latest versions of Herokuish based on `heroku-18`/`heroku-20` stacks respectively can be easily referenced.