### PR TITLE
feat: add initial github actions support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+---
+name: CI
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - master
+
+jobs:
+  lint:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7.x'
+
+      - name: shellcheck
+        run: make shellcheck
+
+      - name: shellcheck
+        run: make lint


### PR DESCRIPTION
CircleCI tends to have issues with workers not being enabled, so moving to Github Actions seems prudent.