### PR TITLE
Draft: Move from circle ci to GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0
+
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7.x'
@@ -33,12 +37,12 @@ jobs:
 
       - name: lint
         run: make lint
-        
+
       - name: install requirements
         run: make deps fpm package_cloud
 
       - name: build
         run: CIRCLECI=true make build
-      
+
       - name: bash tests
         run: basht tests/**/tests.sh

--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,14 @@ endif
 
 fpm:
 ifeq ($(SYSTEM),Linux)
-	sudo apt-get update && sudo apt-get -y install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
-	command -v fpm >/dev/null || gem install fpm --no-ri --no-rdoc
+	sudo apt-get update && sudo apt-get -y install gcc git build-essential wget lintian rpm help2man man-db
+	command -v fpm >/dev/null || gem install fpm --no-document
 endif
 
 package_cloud:
 ifeq ($(SYSTEM),Linux)
-	sudo apt-get update && sudo apt-get -y install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
-	command -v package_cloud >/dev/null || gem install package_cloud --no-ri --no-rdoc
+	sudo apt-get update && sudo apt-get -y install gcc git build-essential wget lintian rpm help2man man-db
+	command -v package_cloud >/dev/null || gem install package_cloud --no-document
 endif
 
 


### PR DESCRIPTION
Attempt to make some test to help on #705.

Details about changes:
- Use official ruby action to install `fpm` and `package_cloud` gems
- Remove ruby installation from `Makefile` (don't sure if you use it outside of CI)
- Using ruby `3.0` so replacing `--no-ri --no-rdoc` by `--no-document` 

After that it's `make build` that seems to failed but can't help more on this. I hope this may help you a bit.