### PR TITLE
fix: don't require binary in ci mode make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,11 @@ build: bindata.go
 	$(MAKE) build/deb/$(NAME)_$(VERSION)_amd64.deb
 
 build/docker:
-	chmod +x build/linux/$(NAME) build/darwin/$(NAME)
 ifeq ($(CIRCLECI),true)
 	docker build -t $(IMAGE_NAME):$(BUILD_TAG) .
 	docker build -t $(IMAGE_NAME):$(BUILD_TAG)-20 --build-arg STACK_VERSION=20 .
 else
+	chmod +x build/linux/$(NAME) build/darwin/$(NAME)
 	docker build -f Dockerfile.dev -t $(IMAGE_NAME):$(BUILD_TAG) .
 	docker build -f Dockerfile.dev -t $(IMAGE_NAME):$(BUILD_TAG)-20 --build-arg STACK_VERSION=20 .
 endif


### PR DESCRIPTION
This PR allows to run `CIRCLECI=true make build/docker` to build a docker image without local go tools. Without this change, the build fails due to missing binary (which is not actually needed with `CIRCLE=true`).

This is useful for https://github.com/dokku/dokku/issues/4944.