### PR TITLE
Pin to a version of markupsafe that works with older jinja2

### DIFF
--- a/buildpacks/buildpack-multi/tests/multi/requirements.txt
+++ b/buildpacks/buildpack-multi/tests/multi/requirements.txt
@@ -1,3 +1,4 @@
 Flask==1.0
 Jinja2==2.11.3
 gunicorn==19.5.0
+markupsafe==2.0.1

--- a/buildpacks/buildpack-multi/tests/multi/requirements.txt
+++ b/buildpacks/buildpack-multi/tests/multi/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.0
+Flask==1.1.4
 Jinja2==2.11.3
 gunicorn==19.5.0
 markupsafe==2.0.1

--- a/buildpacks/buildpack-python/tests/python-flask/requirements.txt
+++ b/buildpacks/buildpack-python/tests/python-flask/requirements.txt
@@ -1,3 +1,4 @@
-Flask==1.0
+Flask==1.1.4
 Jinja2==2.11.3
 gunicorn==19.5.0
+markupsafe==2.0.1


### PR DESCRIPTION
This is fine as it is just to check that a buildpack installs dependencies. These apps aren't in direct use otherwise.

Refs pallets/markupsafe#284