### PR TITLE
chore: split out actions workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - master
-      - 'release'
 
 concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}
@@ -94,7 +93,6 @@ jobs:
           name: build-${{ matrix.heroku }}-${{ matrix.buildx }}
           path: build
 
-
   unit-tests:
     name: unit.heroku-${{ matrix.heroku }}.${{ matrix.buildpack }}
     needs: build
@@ -148,43 +146,3 @@ jobs:
         run: |
           echo "executing ${{ matrix.buildpack }} tests"
           basht buildpacks/${{ matrix.buildpack }}/tests/*/test.sh
-
-  release:
-    name: release
-    needs: unit-tests
-    runs-on: ubuntu-20.04
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.6
-
-      - name: download packages
-        uses: actions/download-artifact@v3
-        with:
-          name: build-22-false
-          path: build
-
-      - name: validate packages
-        run: |
-          ls -lah build build/* bin/*
-
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: release
-        run: |
-          if [[ "${GITHUB_REF#refs/heads/}" == "release" ]]; then
-            export CI_BRANCH=${GITHUB_REF#refs/heads/}
-            export PACKAGECLOUD_REPOSITORY=dokku/dokku
-            make release release-packagecloud
-          fi
-        env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: build
+    name: release
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,42 @@
+---
+name: tag release
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - 'release'
+
+jobs:
+  tag-release:
+    name: tag-release
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      - name: download packages
+        uses: actions/download-artifact@v3
+        with:
+          name: build-22-false
+          path: build
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: release
+        run: |
+          export CI_BRANCH=${GITHUB_REF#refs/heads/}
+          export PACKAGECLOUD_REPOSITORY=dokku/dokku
+          make release release-packagecloud
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}


### PR DESCRIPTION
This ensures the release tagging workflow _only_ ever gets run when we've actually merged to the release branch, vs every time.