### PR TITLE
Drop Ubuntu 18 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
           - "true"
           - "false"
         heroku:
-          - 18
           - 20
           - 22
 
@@ -117,7 +116,6 @@ jobs:
           - buildpack-scala
           - buildpack-static
         heroku:
-          - 18
           - 20
           - 22
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         heroku:
-          - 18
           - 20
           - 22
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG STACK_VERSION=18
+ARG STACK_VERSION=20
 
 FROM golang:1.20 AS builder
 RUN mkdir /src
@@ -10,7 +10,7 @@ ARG VERSION
 RUN go build -a -ldflags "-X main.Version=$VERSION" -o herokuish .
 
 FROM ubuntu:${STACK_VERSION}.04 AS base
-ARG STACK_VERSION=18
+ARG STACK_VERSION=20
 ARG TARGETARCH
 
 ADD https://raw.githubusercontent.com/heroku/stack-images/main/heroku-${STACK_VERSION}/setup.sh /tmp/setup-01.sh

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SHELL := /bin/bash
 SYSTEM := $(shell sh -c 'uname -s 2>/dev/null')
 DOCKER_ARGS ?= "--pull"
 BUILDX ?= true
-STACK_VERSION ?= 18
+STACK_VERSION ?= 20
 
 shellcheck:
 ifneq ($(shell shellcheck --version > /dev/null 2>&1 ; echo $$?),0)
@@ -55,13 +55,12 @@ build: bindata.go
 	$(MAKE) build/deb/$(NAME)_$(VERSION)_all.deb
 
 build/docker:
-	$(MAKE) build/docker/18 STACK_VERSION=18
 	$(MAKE) build/docker/20 STACK_VERSION=20
 	$(MAKE) build/docker/22 STACK_VERSION=22
 
 build/docker/$(STACK_VERSION): bindata.go
 ifeq ($(BUILDX),true)
-ifeq ($(STACK_VERSION),18)
+ifeq ($(STACK_VERSION),20)
 	docker buildx build --no-cache ${DOCKER_ARGS} --pull --progress plain --platform linux/arm,linux/arm64/v8,linux/amd64 --build-arg STACK_VERSION=$(STACK_VERSION) --build-arg VERSION=$(VERSION) -t $(IMAGE_NAME):$(BUILD_TAG)-$(STACK_VERSION) -t $(IMAGE_NAME):latest-$(STACK_VERSION) -t $(IMAGE_NAME):$(BUILD_TAG) -t $(IMAGE_NAME):latest .
 else
 	docker buildx build --no-cache ${DOCKER_ARGS} --pull --progress plain --platform linux/arm,linux/arm64/v8,linux/amd64 --build-arg STACK_VERSION=$(STACK_VERSION) --build-arg VERSION=$(VERSION) -t $(IMAGE_NAME):$(BUILD_TAG)-$(STACK_VERSION) -t $(IMAGE_NAME):latest-$(STACK_VERSION) .
@@ -127,7 +126,6 @@ clean:
 	docker rmi herokuish:dev || true
 
 deps: bindata.go
-	docker pull heroku/heroku:18-build
 	docker pull heroku/heroku:20-build
 	docker pull heroku/heroku:22-build
 	cd / && go get -u github.com/progrium/basht/...

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A command line tool for emulating Heroku build and runtime tasks in containers.
 
 Herokuish is made for platform authors. The project consolidates and decouples Heroku compatibility logic (running buildpacks, parsing Procfile) and supporting workflow (importing/exporting slugs) from specific platform images like those in Dokku/Buildstep, Deis, Flynn, etc.
 
-The goal is to be the definitive, well maintained and heavily tested Heroku emulation utility shared by all. It is based on the [Heroku:18, Heroku:20, and Heroku:22 system images](https://github.com/heroku/stack-images). Together they form a toolkit for achieving Heroku compatibility.
+The goal is to be the definitive, well maintained and heavily tested Heroku emulation utility shared by all. It is based on the [Heroku:20, and Heroku:22 system images](https://github.com/heroku/stack-images). Together they form a toolkit for achieving Heroku compatibility.
 
 Herokuish is a community project and is in no way affiliated with Heroku.
 

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -17,7 +17,7 @@ if [[ -n "$TARGETARCH" ]] && [[ "$TARGETARCH" != "amd64" ]]; then
   sed -i '/syslinux/d' /tmp/setup-01.sh
 fi
 
-# Skip unsupported postgresql on arm:18 and arm:20
+# Skip unsupported postgresql on arm:20
 if [[ "$TARGETARCH" == "arm" ]]; then
   sed -i '/postgresql-client-15/d' /tmp/setup-01.sh
 fi
@@ -41,7 +41,7 @@ rm -rf /var/lib/apt/lists/*
 echo "$setup_02" > /tmp/setup-02.sh
 chmod +x /tmp/setup-02.sh
 
-# Skip unsupported postgresql on arm:18 and arm:20
+# Skip unsupported postgresql on arm:20
 if [[ "$TARGETARCH" == "arm" ]]; then
   sed -i '/postgresql-server-dev-15/d' /tmp/setup-02.sh
 fi

--- a/contrib/post-install
+++ b/contrib/post-install
@@ -19,9 +19,7 @@ fi
 
 VERSION=$(cat /var/lib/herokuish/VERSION)
 
-sudo docker pull "gliderlabs/herokuish:v${VERSION}-18"
 sudo docker pull "gliderlabs/herokuish:v${VERSION}-20"
 sudo docker pull "gliderlabs/herokuish:v${VERSION}-22"
-sudo docker tag "gliderlabs/herokuish:v${VERSION}-18" gliderlabs/herokuish:latest
 sudo docker tag "gliderlabs/herokuish:v${VERSION}-20" gliderlabs/herokuish:latest-20
 sudo docker tag "gliderlabs/herokuish:v${VERSION}-22" gliderlabs/herokuish:latest-22

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -148,7 +148,7 @@ buildpack-setup() {
 	# shellcheck disable=SC2154
 	export HOME="$app_path"
 	export REQUEST_ID="build-$RANDOM"
-	export STACK="${STACK:-heroku-18}"
+	export STACK="${STACK:-heroku-20}"
 	# build_path defined in outer scope
 	# shellcheck disable=SC2154
 	cp -r "$app_path/." "$build_path"


### PR DESCRIPTION
This will be unsupported at the end of the month, so we're dropping support ahead of that since builds won't work at that time.