### PR TITLE
Release v0.5.42

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -8,8 +8,56 @@ on:
       - 'release'
 
 jobs:
+  build:
+    name: build.${{ matrix.heroku }}-${{ matrix.buildx }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: true
+      matrix:
+        buildx:
+          - "false"
+        heroku:
+          - 22
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.17.8
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      - name: set up qemu
+        uses: docker/setup-qemu-action@v2
+
+      - name: set up docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.7.x'
+
+      - name: install requirements
+        run: make deps fpm package_cloud
+
+      - name: build
+        run: |
+          make build build/docker/${{ matrix.heroku }} BUILDX=false STACK_VERSION=${{ matrix.heroku }}
+
+      - name: upload packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ matrix.heroku }}-${{ matrix.buildx }}
+          path: build
+
   tag-release:
     name: tag-release
+    needs: build
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
- @dependabot chore(deps-dev): bump rack-test from 2.0.2 to 2.1.0 in /buildpacks/buildpack-ruby/tests/ruby-sinatra #889
- @dependabot chore(deps-dev): bump test-unit from 3.5.7 to 3.5.9 in /buildpacks/buildpack-ruby/tests/ruby-sinatra #919
- @dependabot chore(deps): bump actions/setup-go from 3 to 4 #891
- @dependabot chore(deps): bump flask from 2.2.3 to 2.3.2 in /buildpacks/buildpack-multi/tests/multi #915
- @dependabot chore(deps): bump flask from 2.2.3 to 2.3.2 in /buildpacks/buildpack-python/tests/python-flask #914
- @dependabot chore(deps): bump github.com/progrium/go-basher from 0.0.0-20190315062444-ad5de635edd1 to 5.1.6+incompatible #881
- @dependabot chore(deps): bump maven-compiler-plugin from 3.10.1 to 3.11.0 in /buildpacks/buildpack-java/tests/java-jetty #882
- @dependabot chore(deps): bump maven-dependency-plugin from 3.5.0 to 3.6.0 in /buildpacks/buildpack-java/tests/java-jetty #918
- @dependabot chore(deps): bump puma from 6.1.0 to 6.1.1 in /buildpacks/buildpack-ruby/tests/ruby-sinatra #883
- @dependabot chore(deps): bump puma from 6.1.1 to 6.2.2 in /buildpacks/buildpack-ruby/tests/ruby-sinatra #910
- @dependabot chore(deps): bump rack from 2.2.6.2 to 2.2.6.4 in /buildpacks/buildpack-ruby/tests/ruby-sinatra #888
- @dependabot chore(deps): bump rack from 2.2.6.4 to 2.2.7 in /buildpacks/buildpack-multi/tests/multi #920
- @dependabot chore(deps): bump rack from 2.2.6.4 to 2.2.7 in /buildpacks/buildpack-ruby/tests/ruby-sinatra #911
- @dependabot chore(deps): bump rack from 2.2.6.4 to 3.0.7 in /buildpacks/buildpack-multi/tests/multi #903
- @dependabot chore(deps): bump rack from 3.0.4.1 to 3.0.7 in /buildpacks/buildpack-multi/tests/multi #890
- @dependabot chore(deps): bump sinatra from 1.0 to 3.0.5 in /buildpacks/buildpack-multi/tests/multi #875
- @dependabot chore(deps): bump sinatra from 1.0 to 3.0.5 in /buildpacks/buildpack-multi/tests/multi #904
- @dependabot chore(deps): bump sinatra from 3.0.5 to 3.0.6 in /buildpacks/buildpack-multi/tests/multi #908
- @dependabot chore(deps): bump sinatra from 3.0.5 to 3.0.6 in /buildpacks/buildpack-ruby/tests/ruby-sinatra #909
- @dependabot chore(deps): bump twig/twig from 3.5.1 to 3.6.0 in /buildpacks/buildpack-php/tests/php #916
- @henningjensen Don't fail in post-install when no dangling images are present #815
- @josegonzalez chore: drop all references to circleci #921
- @josegonzalez chore: split out actions workflows #922
- @josegonzalez Update go to version v174 #928
- @josegonzalez Update nodejs to version v205 #901
- @josegonzalez Update nodejs to version v213 #926
- @josegonzalez Update php to version v234 #924
- @josegonzalez Update python to version v229 #902
- @josegonzalez Update python to version v232 #927
- @josegonzalez Update ruby to version v254 #929
- @josegonzalez Update static to version v23 #925
- @josegonzalez Partially revert workflow refactor to fix tagging