### PR TITLE
Only install the 22 stack via deb package

### DIFF
--- a/contrib/post-install
+++ b/contrib/post-install
@@ -19,7 +19,5 @@ fi
 
 VERSION=$(cat /var/lib/herokuish/VERSION)
 
-sudo docker pull "gliderlabs/herokuish:v${VERSION}-20"
 sudo docker pull "gliderlabs/herokuish:v${VERSION}-22"
-sudo docker tag "gliderlabs/herokuish:v${VERSION}-20" gliderlabs/herokuish:latest-20
 sudo docker tag "gliderlabs/herokuish:v${VERSION}-22" gliderlabs/herokuish:latest-22


### PR DESCRIPTION
Most folks only actually use one stack at a time, and using the latest stack is probably a better idea than something slightly outdated, security-wise.