### PR TITLE
feat: upgrade to ruby 3.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.3
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This should help fix issues with installing ruby dependencies for fpm.