### PR TITLE
Add ability for users to disable the chown process on container start

### DIFF
--- a/include/procfile.bash
+++ b/include/procfile.bash
@@ -118,8 +118,10 @@ procfile-load-profile() {
 
 procfile-setup-home() {
 	export HOME="$app_path"
-	usermod --home "$app_path" "$unprivileged_user" > /dev/null 2>&1
-	# unprivileged_user & unprivileged_group are defined in outer scope
-	# shellcheck disable=SC2154
-	find "$app_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -0 -r chown "$unprivileged_user:$unprivileged_group"
+	usermod --home "$app_path" "$unprivileged_user" >/dev/null 2>&1
+	if [[ "$HEROKUISH_DISABLE_CHOWN" == "true" ]]; then
+		# unprivileged_user & unprivileged_group are defined in outer scope
+		# shellcheck disable=SC2154
+		find "$app_path" \( \! -user "$unprivileged_user" -o \! -group "$unprivileged_group" \) -print0 | xargs -0 -r chown "$unprivileged_user:$unprivileged_group"
+	fi
 }


### PR DESCRIPTION
If the container files in the APP_PATH are already chowned by the herokuishuser during image creation, there is no need to perform the task again on each container start.

While the `find` should help with that, we can short-circuit a potentially long startup time by just disabling it completely.