### PR TITLE
Ensure all file permissions are set to specified unprivileged user

### DIFF
--- a/include/procfile.bash
+++ b/include/procfile.bash
@@ -103,6 +103,7 @@ procfile-load-profile() {
     source "$file"
   done
   mkdir -p "$app_path/.profile.d"
+  # shellcheck disable=SC2154
   chown "$unprivileged_user:$unprivileged_group" "$app_path/.profile.d"
   for file in "$app_path/.profile.d"/*.sh; do
     # shellcheck disable=SC1090


### PR DESCRIPTION
This change avoids a potentially heavy chown operation at the start of the container process - in fact, it may even allow us to drop perm changes completely - by ensuring any created files are _always_ set to the correct permissions.