### PR TITLE
feat: use system bash to avoid extracting bash at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,3 +53,4 @@ RUN /bin/herokuish buildpack install \
     */tmp
 COPY include/default_user.bash /tmp/default_user.bash
 RUN bash /tmp/default_user.bash && rm -f /tmp/default_user.bash
+ENV BASH_BIN /usr/bin/bash


### PR DESCRIPTION
When herokuish executes, it extracts a bash binary into the HOME directory - /app - and then executes as normal. This makes it impossible to run read-only containers, as that extraction happens at both build time (when executing buildpacks) as well as runtime (when running applications).

Rather than attempt to move the bash binary to /tmp, we instead use system bash. While this is a downgrade of bash since we packaged a newer bash, this provides better compatibility with upstream Heroku, which executes shell buildpacks with system bash.