### PR TITLE
Don't try to delete dangling images if none is present

### DIFF
--- a/contrib/post-install
+++ b/contrib/post-install
@@ -7,7 +7,7 @@ if which systemctl >/dev/null; then
 fi
 
 echo "Pruning dangling images"
-docker images -qf dangling=true | xargs docker rmi || true
+docker images -qf dangling=true | xargs --no-run-if-empty docker rmi
 
 echo "Pruning unused gliderlabs/herokuish images"
 docker images -a | grep "^gliderlabs\/herokuish" | grep -v latest | awk '{print $3}' | xargs -r docker rmi || true


### PR DESCRIPTION
This fix won't try to run `xargs` if there's no dangling images, so `|| true` is not needed and we're going to avoid the `docker rmi` error message as in:

```
Setting up herokuish (0.10.3) ...
Starting docker
Pruning dangling images
"docker rmi" requires at least 1 argument.
See 'docker rmi --help'.

Usage:  docker rmi [OPTIONS] IMAGE [IMAGE...]

Remove one or more images
Pruning unused gliderlabs/herokuish images
Importing herokuish into docker (around 5 minutes)
v0.10.3-24: Pulling from gliderlabs/herokuish
afad30e59d72: Pull complete 
d6acde479388: Pull complete 
05b78ec5257c: Pull complete 
c116e4a70b85: Pull complete 
e34d21eca2e2: Pull complete 
aa8c90b819fc: Pull complete 
c8d0cbf3056c: Pull complete 
dcee7c326922: Pull complete 
fa8e0941d0aa: Pull complete 
09ed1dbe0885: Pull complete 
Digest: sha256:4b2b953dc1abfe4f79bef1e798ef2f039857a20b99aea0ca53ed0f60d483337b
Status: Downloaded newer image for gliderlabs/herokuish:v0.10.3-24
docker.io/gliderlabs/herokuish:v0.10.3-24
```