### PR TITLE
Expose detect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 include/cedarish.txt
 include/buildpacks.txt
 bindata.go
+.idea/

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -70,6 +70,12 @@ _select-buildpack() {
   fi
 }
 
+buildpack-detect() {
+	declare desc="Detect suitable buildpack for an application"
+	ensure-paths
+	_select-buildpack
+}
+
 buildpack-build() {
   declare desc="Build an application using installed buildpacks"
   ensure-paths

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -69,7 +69,7 @@ _select-buildpack() {
     fi
     if [[ ${#valid_buildpacks[@]} -gt 0 ]]; then
       selected_path="${valid_buildpacks[0]}"
-      selected_name=$(unprivileged "$selected_path/bin/detect" "$build_path")
+      selected_name=$(unprivileged "$selected_path/bin/detect" "$checked_out_path")
     fi
   fi
   if [[ "$selected_path" ]] && [[ "$selected_name" ]]; then

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -38,6 +38,7 @@ _select-buildpack() {
 		echo "Detected bare repo at $checked_out_path, checking out worktree..."
 		tmpdir=$(mktemp -d)
 		git --git-dir="$checked_out_path" --work-tree="$tmpdir" checkout -f &>/dev/null
+		chown -R "$unprivileged_user:$unprivileged_group" "$tmpdir"
 		checked_out_path="$tmpdir"
 	fi
   if [[ -n "$BUILDPACK_URL" ]]; then

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -83,6 +83,8 @@ _select-buildpack() {
 buildpack-detect() {
 	declare desc="Detect suitable buildpack for an application"
 	ensure-paths
+	[[ "$USER" ]] || randomize-unprivileged
+	buildpack-setup >/dev/null
 	_select-buildpack
 }
 

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -73,9 +73,25 @@ _select-buildpack() {
     fi
   fi
   if [[ "$selected_path" ]] && [[ "$selected_name" ]]; then
-    title "$selected_name app detected"
+    if [[ "${BUILDPACK_DETECT_OUTPUT}" == "json" ]]; then
+      # Strip leading number and "buildpack-" prefix
+      buildpack_id=$(basename "$selected_path")
+      buildpack_id="${buildpack_id#*_buildpack-}"
+
+      # Output proper JSON
+			jq -n \
+				--arg name "$selected_name" \
+				--arg id "$buildpack_id" \
+				'{name: $name, id: $id}'
+    else
+      title "$selected_name app detected"
+    fi
   else
-    title "Unable to select a buildpack"
+    if [[ "${BUILDPACK_DETECT_OUTPUT}" == "json" ]]; then
+      jq -n '{error: "Unable to select a buildpack"}'
+    else
+      title "Unable to select a buildpack"
+    fi
     exit 1
   fi
 }

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -34,10 +34,10 @@ _move-build-to-app() {
 _select-buildpack() {
 	local checked_out_path="$build_path"
 	# checkout app code if build_path is a bare git repo
-	if [ -f "$checked_out_path/HEAD" ] && [ -d "$checked_out_path/objects" ]; then
-		echo "Detected bare repo at $checked_out_path, checking out worktree..."
+	if [ -f "$build_path/HEAD" ] && [ -d "$build_path/objects" ]; then
+		#	If bare repo is detected, check out worktree, as expected by buildpacks
 		tmpdir=$(mktemp -d)
-		git --git-dir="$checked_out_path" --work-tree="$tmpdir" checkout -f &>/dev/null
+		git --git-dir="$build_path" --work-tree="$tmpdir" checkout -f &>/dev/null
 		chown -R "$unprivileged_user:$unprivileged_group" "$tmpdir"
 		checked_out_path="$tmpdir"
 	fi

--- a/include/herokuish.bash
+++ b/include/herokuish.bash
@@ -133,6 +133,7 @@ main() {
   cmd-export buildpack-install
   cmd-export buildpack-list
   cmd-export buildpack-test
+  cmd-export buildpack-detect
 
   cmd-export-ns slug "Manage application slugs"
   cmd-export slug-import


### PR DESCRIPTION
I am working on a feature and want to be able to call this via dokku. Ideally `dokku buildpacks:detect app_name`, alternatively via a custom plugin. Let me know which one would make more sense.

Basically just needs to run something like this:
```
docker run --rm \
  -v "$APP_ROOT:/tmp/app" \
  ${BUILDPACK_DETECT_OUTPUT:+-e BUILDPACK_DETECT_OUTPUT="$BUILDPACK_DETECT_OUTPUT"} \
  gliderlabs/herokuish \
  /bin/herokuish buildpack detect /tmp/app
;;
```

If this is moved into buildpacks (or a separate) plugin, then the part that checks out a potential bare git repo, could probably be moved there as well and just run before the command above. Not sure about permissions complications.