### PR TITLE
Give access to tty for unprivileged and herokuish user

### DIFF
--- a/include/default_user.bash
+++ b/include/default_user.bash
@@ -11,5 +11,8 @@ addgroup --quiet --gid "32767" "herokuishuser" \
     --gecos '' \
     --quiet \
     --home "/app" \
-    "herokuishuser" \
-  && usermod -aG tty herokuishuser
+    "herokuishuser"
+
+if [ -n "$HEROKUISH_WITH_TTY" ]; then
+  usermod -aG tty herokuishuser
+fi

--- a/include/default_user.bash
+++ b/include/default_user.bash
@@ -11,4 +11,5 @@ addgroup --quiet --gid "32767" "herokuishuser" \
     --gecos '' \
     --quiet \
     --home "/app" \
-    "herokuishuser"
+    "herokuishuser" \
+  && usermod -aG tty herokuishuser

--- a/include/herokuish.bash
+++ b/include/herokuish.bash
@@ -59,7 +59,11 @@ indent() {
 }
 
 unprivileged() {
-  runuser -u "$unprivileged_user" -- "$@"
+  if [ -n "$HEROKUISH_WITH_TTY" ]; then
+    runuser -u "$unprivileged_user" -- "$@"
+  else
+    setuidgid "$unprivileged_user" "$@"
+  fi
 }
 
 detect-unprivileged() {
@@ -83,7 +87,10 @@ randomize-unprivileged() {
     --quiet \
     --home "$app_path" \
     "$username"
-  usermod -aG tty "$username"
+
+  if [ -n "$HEROKUISH_WITH_TTY" ]; then
+    usermod -aG tty "$username"
+  fi
 
   unprivileged_user="$username"
   unprivileged_group="$username"

--- a/include/herokuish.bash
+++ b/include/herokuish.bash
@@ -59,7 +59,7 @@ indent() {
 }
 
 unprivileged() {
-  setuidgid "$unprivileged_user" "$@"
+  runuser -u "$unprivileged_user" -- "$@"
 }
 
 detect-unprivileged() {
@@ -83,6 +83,7 @@ randomize-unprivileged() {
     --quiet \
     --home "$app_path" \
     "$username"
+  usermod -aG tty "$username"
 
   unprivileged_user="$username"
   unprivileged_group="$username"


### PR DESCRIPTION
resolves #1818

Some heroku buildpack like heroku-buildpack-php needs access to `/dev/stderr`. For this, the unprivileged user needs to be added to the tty group. Also, `setuidgid` "sets its uid and gid to account's uid and gid, removing all supplementary groups. It then runs child." My understanding is that it only adds the main group. I propose to use `runuser` with `-u` option as an alternative because it keeps supplementary groups.