### PR TITLE
Fix readonly variable warnings during bash re-sourcing

### DIFF
--- a/include/herokuish.bash
+++ b/include/herokuish.bash
@@ -4,12 +4,12 @@ if [[ "${BASH_VERSINFO[0]}" -lt "4" ]]; then
   exit 2
 fi
 
-readonly app_path="${APP_PATH:-/app}"
-readonly env_path="${ENV_PATH:-/tmp/env}"
-readonly build_path="${BUILD_PATH:-/tmp/build}"
-readonly cache_path="${CACHE_PATH:-/tmp/cache}"
-readonly import_path="${IMPORT_PATH:-/tmp/app}"
-readonly buildpack_path="${BUILDPACK_PATH:-/tmp/buildpacks}"
+[[ -z "${app_path+x}" ]] && readonly app_path="${APP_PATH:-/app}"
+[[ -z "${env_path+x}" ]] && readonly env_path="${ENV_PATH:-/tmp/env}"
+[[ -z "${build_path+x}" ]] && readonly build_path="${BUILD_PATH:-/tmp/build}"
+[[ -z "${cache_path+x}" ]] && readonly cache_path="${CACHE_PATH:-/tmp/cache}"
+[[ -z "${import_path+x}" ]] && readonly import_path="${IMPORT_PATH:-/tmp/app}"
+[[ -z "${buildpack_path+x}" ]] && readonly buildpack_path="${BUILDPACK_PATH:-/tmp/buildpacks}"
 
 declare unprivileged_user="$USER"
 declare unprivileged_group="${USER/nobody/nogroup}"

--- a/include/slug.bash
+++ b/include/slug.bash
@@ -1,4 +1,4 @@
-readonly slug_path="/tmp/slug.tgz"
+[[ -z "${slug_path+x}" ]] && readonly slug_path="/tmp/slug.tgz"
 
 slug-import() {
   declare desc="Import a gzipped slug tarball from URL or STDIN "


### PR DESCRIPTION
## Summary

- Guard `readonly` declarations in `include/herokuish.bash` and `include/slug.bash` with `[[ -z "${varname+x}" ]]` checks to skip assignment when variables are already set
- go-basher concatenates all scripts into a bashenv file that gets re-sourced on every subprocess spawn, causing `readonly` to emit warnings on subsequent sources
- Variables remain readonly after first initialization; the guard simply prevents the redundant (and noisy) re-declaration