### PR TITLE
Run bin/retag after release images are pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,39 @@ jobs:
         run: |
           export PATH="/home/runner/go/bin:$PATH"
           make build/docker/${{ matrix.heroku }} IMAGE_NAME="$GITHUB_REPOSITORY" BUILD_TAG=${{ steps.get_version.outputs.VERSION }} VERSION=${{ steps.get_version.outputs.VERSION }} DOCKER_ARGS="--push" STACK_VERSION=${{ matrix.heroku }}
+
+  retag:
+    name: retag
+    needs: build
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: set up qemu
+        uses: docker/setup-qemu-action@v4
+
+      - name: set up docker buildx
+        uses: docker/setup-buildx-action@v4
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.7.x"
+
+      - name: install docker-copyedit
+        run: pip install docker-copyedit
+
+      - name: Get the version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+
+      - name: retag images
+        env:
+          DOCKER_CLI_EXPERIMENTAL: enabled
+        run: bin/retag ${{ steps.get_version.outputs.VERSION }}

--- a/bin/retag
+++ b/bin/retag
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+main() {
+  declare TAG="$1"
+  IMAGE=gliderlabs/herokuish
+
+  if [ -z "$TAG" ]; then
+    echo "Usage: $0 <tag>"
+    exit 1
+  fi
+
+  architectures=(amd64 arm64)
+
+  echo "====> Deleting all existing manifests"
+  tags=("${TAG}" "${TAG}-24" "latest" "latest-24")
+  for tag in "${tags[@]}"; do
+    if docker manifest inspect "${IMAGE}:${tag}" 2>/dev/null; then
+      echo "      Deleting manifest for ${IMAGE}:${tag}"
+      docker manifest rm "${IMAGE}:${tag}" || true
+    fi
+  done
+
+  echo "====> Processing $IMAGE:$TAG"
+  for architecture in "${architectures[@]}"; do
+    echo "----> Processing ${architecture}"
+    echo "      Pulling ${IMAGE}:${TAG} for ${architecture}"
+    docker image pull --platform "linux/${architecture}" "${IMAGE}:${TAG}"
+    docker image tag "${IMAGE}:${TAG}" "${IMAGE}:${TAG}-${architecture}"
+    docker image rm "${IMAGE}:${TAG}"
+
+    echo "      Removing label from ${IMAGE}:${TAG}-${architecture}"
+    docker-copyedit.py \
+      FROM "${IMAGE}:${TAG}-${architecture}" \
+      INTO "${IMAGE}:${TAG}-${architecture}-patched" \
+      REMOVE LABEL io.buildpacks.stack.id
+    echo "      Tagging ${IMAGE}:${TAG}-${architecture}-patched as ${IMAGE}:${TAG}-${architecture}"
+    docker image rm "${IMAGE}:${TAG}-${architecture}"
+    docker image tag "${IMAGE}:${TAG}-${architecture}-patched" "${IMAGE}:${TAG}-${architecture}"
+    echo "      Pushing ${IMAGE}:${TAG}-${architecture}"
+    docker image push "${IMAGE}:${TAG}-${architecture}"
+  done
+
+  echo "----> Creating manifests"
+  tags=("${TAG}" "${TAG}-24" "latest" "latest-24")
+  for tag in "${tags[@]}"; do
+    echo "      Creating manifest for ${IMAGE}:${tag}"
+    docker manifest create "${IMAGE}:${tag}" \
+      --amend "${IMAGE}:${TAG}-amd64" \
+      --amend "${IMAGE}:${TAG}-arm64"
+  done
+
+  echo "----> Pushing manifests"
+  for tag in "${tags[@]}"; do
+    echo "      Pushing manifest for ${IMAGE}:${tag}"
+    docker manifest push "${IMAGE}:${tag}"
+  done
+
+  echo " !    Done!"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds a `retag` job to `.github/workflows/release.yml` that `needs: build` and runs once per release tag.
- The job logs into DockerHub, sets up QEMU/buildx, installs `docker-copyedit`, and executes `bin/retag $VERSION`.
- `bin/retag` pulls each per-arch image that the build job just pushed, strips the `io.buildpacks.stack.id` label via `docker-copyedit.py`, re-pushes patched per-arch tags (`$TAG-amd64`, `$TAG-arm64`), and rebuilds the `$TAG`, `$TAG-24`, `latest`, and `latest-24` manifests.
- Previously this cleanup had to be run by hand after every tag; wiring it into CI makes releases fully automatic.