### PR TITLE
Surface errors when custom buildpack download fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ docker run -e BUILDPACK_URL="https://github.com/custom/buildpack.git#with-a-bran
 
 Note that the underlying buildpacks will not trace their commands with `TRACE=true` is enabled. They need to independently set `set -x` in order to trace execution.
 
+`BUILDPACK_URL` must be a git remote (`https://`, `git://`, `ssh://`, `git@host:path`) or a tarball URL ending in `.tgz`, `.tar.gz`, `.tbz`, `.tar.bz`, or `.tar`. If the value is malformed or the download fails, herokuish now exits non-zero with a message such as `!     Invalid buildpack URL: 'ruby'` or `!     Failed to download buildpack from '<url>'` — previously this path could stop silently.
+
 ## Contributing
 
 Pull requests are welcome! Herokuish is written in Bash and Go. Please conform to the [Bash styleguide](https://github.com/progrium/bashstyle) used for this project when writing Bash.

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -40,7 +40,10 @@ _select-buildpack() {
     rm -rf "$selected_path"
 
     IFS='#' read -r url commit <<<"$BUILDPACK_URL"
-    buildpack-install "$url" "$commit" custom &>/dev/null
+    if ! buildpack-install "$url" "$commit" custom; then
+      title "Unable to fetch custom buildpack from $url"
+      exit 1
+    fi
     # unprivileged_user & unprivileged_group defined in outer scope
     # shellcheck disable=SC2154
     chown -R "$unprivileged_user:$unprivileged_group" "$buildpack_path/custom"
@@ -103,26 +106,53 @@ buildpack-install() {
     done
     return
   fi
+
+  # Reject obviously invalid input up-front so failures surface with a clear
+  # message instead of a silent empty install. Accept common git/http/ssh/file
+  # URL shapes, git scp-style addresses, and existing local directories.
+  if [[ ! -d "$url" ]] \
+    && [[ ! "$url" =~ ^(https?|git|ssh|file)://.+ ]] \
+    && [[ ! "$url" =~ ^[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+:.+ ]]; then
+    echo "!     Invalid buildpack URL: '$url'" >&2
+    echo "!     Expected a git remote (https://, git://, ssh://, git@host:path) or a tarball URL (http(s)://...tar.gz|tgz|tar.bz|tbz|tar)." >&2
+    return 1
+  fi
+
+  # pipefail ensures the curl|tar pipeline below surfaces either side's
+  # failure. `local -` scopes the shell option change to this function.
+  local -
+  set -o pipefail
+
   # buildpack_path is defined in outer scope
   # shellcheck disable=SC2154
   local target_path="$buildpack_path/${name:-$(basename "$url")}"
-  if [[ "$(
-    git ls-remote "$url" &>/dev/null
-    echo $?
-  )" -eq 0 ]]; then
+  if git ls-remote "$url" &>/dev/null; then
     if [[ "$commit" ]]; then
       if ! git clone --branch "$commit" --quiet --depth 1 "$url" "$target_path" &>/dev/null; then
         # if the shallow clone failed partway through, clean up and try a full clone
         rm -rf "$target_path"
-        git clone "$url" "$target_path"
+        if ! git clone "$url" "$target_path"; then
+          echo "!     Failed to clone buildpack from '$url'" >&2
+          rm -rf "$target_path"
+          return 1
+        fi
         cd "$target_path" || return 1
-        git checkout --quiet "$commit"
+        if ! git checkout --quiet "$commit"; then
+          echo "!     Failed to checkout '$commit' from '$url'" >&2
+          cd - >/dev/null || true
+          rm -rf "$target_path"
+          return 1
+        fi
         cd - >/dev/null || return 1
       else
         echo "Cloning into '$target_path'..."
       fi
     else
-      git clone --depth=1 "$url" "$target_path"
+      if ! git clone --depth=1 "$url" "$target_path"; then
+        echo "!     Failed to clone buildpack from '$url'" >&2
+        rm -rf "$target_path"
+        return 1
+      fi
     fi
   else
     local tar_args
@@ -141,10 +171,19 @@ buildpack-install() {
         target_path="${target_path//.tar/}"
         tar_args="-xC"
         ;;
+      *)
+        echo "!     Buildpack URL is not a reachable git remote or a recognised archive: '$url'" >&2
+        echo "!     Supported archive extensions: .tgz, .tar.gz, .tbz, .tar.bz, .tar" >&2
+        return 1
+        ;;
     esac
     echo "Downloading '$url' into '$target_path'..."
     mkdir -p "$target_path"
-    curl -s --retry 2 "$url" | tar "$tar_args" "$target_path"
+    if ! curl --fail --silent --show-error --location --retry 2 "$url" | tar "$tar_args" "$target_path"; then
+      echo "!     Failed to download buildpack from '$url'" >&2
+      rm -rf "$target_path"
+      return 1
+    fi
     chown -R root:root "$target_path"
     chmod 755 "$target_path"
   fi

--- a/tests/functional/tests.sh
+++ b/tests/functional/tests.sh
@@ -93,3 +93,64 @@ T_buildpack-detect-fail() {
     herokuish buildpack detect 2>&1 | grep 'Unable to select a buildpack'
   "
 }
+
+# Regression tests for gliderlabs/herokuish#553: a failing custom buildpack
+# download must exit non-zero with an actionable error instead of stopping
+# silently. Each case points BUILDPACK_URL at a different class of bad input.
+
+T_buildpack-install-invalid-url() {
+  herokuish-test "buildpack-install-invalid-url" "
+    set +e
+    export BUILDPACK_URL=ruby
+    output=\$(herokuish buildpack install \"\$BUILDPACK_URL\" 2>&1)
+    rc=\$?
+    set -e
+    if [[ \"\$rc\" -eq 0 ]]; then
+      echo 'expected non-zero exit, got 0'
+      echo \"\$output\"
+      exit 1
+    fi
+    echo \"\$output\" | grep -q \"Invalid buildpack URL: 'ruby'\"
+  "
+}
+
+T_buildpack-install-bad-tarball-url() {
+  herokuish-test "buildpack-install-bad-tarball-url" "
+    set +e
+    export BUILDPACK_URL=https://example.invalid/does-not-exist.tar.gz
+    output=\$(herokuish buildpack install \"\$BUILDPACK_URL\" 2>&1)
+    rc=\$?
+    set -e
+    if [[ \"\$rc\" -eq 0 ]]; then
+      echo 'expected non-zero exit, got 0'
+      echo \"\$output\"
+      exit 1
+    fi
+    echo \"\$output\" | grep -q 'Failed to download buildpack'
+  "
+}
+
+T_buildpack-detect-bad-buildpack-url() {
+  herokuish-test "buildpack-detect-bad-buildpack-url" "
+    set +e
+    export buildpack_path=/tmp/buildpacks
+    export build_path=/tmp/app
+    export unprivileged_user=\$(whoami)
+    export unprivileged_group=\$(id -gn)
+    export BUILDPACK_URL=ruby
+
+    rm -rf \$buildpack_path && mkdir -p \$buildpack_path
+    mkdir -p \$build_path
+
+    output=\$(herokuish buildpack detect 2>&1)
+    rc=\$?
+    set -e
+    if [[ \"\$rc\" -eq 0 ]]; then
+      echo 'expected non-zero exit, got 0'
+      echo \"\$output\"
+      exit 1
+    fi
+    echo \"\$output\" | grep -q \"Invalid buildpack URL: 'ruby'\"
+    echo \"\$output\" | grep -q 'Unable to fetch custom buildpack from ruby'
+  "
+}

--- a/tests/unit/tests.sh
+++ b/tests/unit/tests.sh
@@ -37,6 +37,71 @@ T_envfile-parse() {
   fi
 }
 
+T_buildpack-install-invalid-url() {
+  # Regression test for gliderlabs/herokuish#553: a non-URL input like "ruby"
+  # must fail up-front with an actionable error instead of silently installing
+  # an empty buildpack directory.
+  # shellcheck disable=SC1091
+  source "$(dirname "${BASH_SOURCE[0]}")/../../include/buildpack.bash"
+
+  # Stub out ensure-paths and scope buildpack_path to a temp dir so the test
+  # does not touch /tmp/buildpacks or require the outer scope vars.
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  # shellcheck disable=SC2317
+  ensure-paths() { :; }
+  local buildpack_path="$tmpdir"
+  local output rc
+
+  output="$(buildpack-install "ruby" "" "custom" 2>&1)"
+  rc=$?
+  rm -rf "$tmpdir"
+
+  if [[ "$rc" -eq 0 ]]; then
+    echo "Expected non-zero exit code for invalid URL, got 0"
+    echo "output: $output"
+    return 1
+  fi
+
+  if [[ "$output" != *"Invalid buildpack URL: 'ruby'"* ]]; then
+    echo "Expected 'Invalid buildpack URL' message, got: $output"
+    return 2
+  fi
+}
+
+T_buildpack-install-unrecognised-archive() {
+  # An http(s) URL that is not a known archive extension and is not a reachable
+  # git remote should fail with an explicit "not a recognised archive" error
+  # rather than silently running tar with empty args.
+  # shellcheck disable=SC1091
+  source "$(dirname "${BASH_SOURCE[0]}")/../../include/buildpack.bash"
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  # shellcheck disable=SC2317
+  ensure-paths() { :; }
+  local buildpack_path="$tmpdir"
+  local output rc
+
+  # Use a reserved-for-documentation host so git ls-remote definitely fails
+  # and the tarball branch is reached without network access attempting real
+  # downloads.
+  output="$(buildpack-install "https://example.invalid/not-an-archive" "" "custom" 2>&1)"
+  rc=$?
+  rm -rf "$tmpdir"
+
+  if [[ "$rc" -eq 0 ]]; then
+    echo "Expected non-zero exit code for unrecognised archive URL, got 0"
+    echo "output: $output"
+    return 1
+  fi
+
+  if [[ "$output" != *"not a reachable git remote or a recognised archive"* ]]; then
+    echo "Expected 'not a reachable git remote or a recognised archive' message, got: $output"
+    return 2
+  fi
+}
+
 T_procfile-parse-valid() {
   # shellcheck disable=SC1091
   source "$(dirname "${BASH_SOURCE[0]}")/../../include/procfile.bash"


### PR DESCRIPTION
## Summary

- Validate `BUILDPACK_URL` shape up-front and reject bare strings like `ruby` with an actionable `Invalid buildpack URL` message instead of a silent empty install (#553).
- Enable `pipefail` inside `buildpack-install`, switch `curl -s` to `curl --fail --silent --show-error --location`, and check exit codes for every `git clone`/`curl|tar` branch so download failures print `Failed to download buildpack from '<url>'` and exit non-zero.
- Drop the `&>/dev/null` around the custom `buildpack-install` call in `_select-buildpack` so users can see fetch output; on failure it now prints `Unable to fetch custom buildpack from <url>` and exits.
- Add unit and functional basht coverage for invalid-URL, unrecognised-archive, and bad-URL-during-detect paths, and update the README troubleshooting note.

Fixes #553