### PR TITLE
Treat single-entry .buildpacks as BUILDPACK_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ Note that the underlying buildpacks will not trace their commands with `TRACE=tr
 
 `BUILDPACK_URL` must be a git remote (`https://`, `git://`, `ssh://`, `git@host:path`) or a tarball URL ending in `.tgz`, `.tar.gz`, `.tbz`, `.tar.bz`, or `.tar`. If the value is malformed or the download fails, herokuish now exits non-zero with a message such as `!     Invalid buildpack URL: 'ruby'` or `!     Failed to download buildpack from '<url>'` — previously this path could stop silently.
 
+If `BUILDPACK_URL` is not set and the app's build directory contains a `.buildpacks` file with exactly one entry, herokuish treats that entry as `BUILDPACK_URL`. This bypasses `heroku-buildpack-multi` (and its "Multiple default buildpacks reported" warning) when only one buildpack is declared, since there is no real ambiguity. A `.buildpacks` file with two or more entries still goes through `heroku-buildpack-multi` as before. An explicit `BUILDPACK_URL` always wins over the file.
+
 ## Contributing
 
 Pull requests are welcome! Herokuish is written in Bash and Go. Please conform to the [Bash styleguide](https://github.com/progrium/bashstyle) used for this project when writing Bash.

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -32,6 +32,29 @@ _move-build-to-app() {
 }
 
 _select-buildpack() {
+  # Issue #554: if .buildpacks declares exactly one buildpack, treat it as
+  # BUILDPACK_URL. Bypasses heroku-buildpack-multi (and its misleading
+  # "Multiple default buildpacks reported" warning) when the user has only
+  # declared a single buildpack — there is nothing "multi" about that case.
+  # A caller-provided BUILDPACK_URL always wins.
+  # shellcheck disable=SC2154
+  if [[ -z "$BUILDPACK_URL" ]] && [[ -f "$build_path/.buildpacks" ]]; then
+    local -a _dotbuildpacks_urls=()
+    local _dotbuildpacks_line
+    while IFS= read -r _dotbuildpacks_line || [[ -n "$_dotbuildpacks_line" ]]; do
+      _dotbuildpacks_line="${_dotbuildpacks_line%$'\r'}"
+      _dotbuildpacks_line="${_dotbuildpacks_line#"${_dotbuildpacks_line%%[![:space:]]*}"}"
+      _dotbuildpacks_line="${_dotbuildpacks_line%"${_dotbuildpacks_line##*[![:space:]]}"}"
+      [[ -z "$_dotbuildpacks_line" ]] && continue
+      [[ "${_dotbuildpacks_line:0:1}" == "#" ]] && continue
+      _dotbuildpacks_urls+=("$_dotbuildpacks_line")
+    done <"$build_path/.buildpacks"
+
+    if [[ "${#_dotbuildpacks_urls[@]}" -eq 1 ]]; then
+      BUILDPACK_URL="${_dotbuildpacks_urls[0]}"
+    fi
+  fi
+
   if [[ -n "$BUILDPACK_URL" ]]; then
     title "Fetching custom buildpack"
     # buildpack_path defined in outer scope

--- a/tests/functional/tests.bats
+++ b/tests/functional/tests.bats
@@ -128,6 +128,87 @@ teardown_file() {
   "
 }
 
+# Regression test for gliderlabs/herokuish#554: when .buildpacks declares a
+# single buildpack, herokuish should route through the custom BUILDPACK_URL
+# path — skipping heroku-buildpack-multi and its "Multiple default buildpacks"
+# warning — because there is no real ambiguity.
+@test "buildpack-detect-single-url-in-dotbuildpacks" {
+  herokuish-test "buildpack-detect-single-url-in-dotbuildpacks" "
+    set -e
+    unset BUILDPACK_URL
+    export buildpack_path=/tmp/buildpacks
+    export build_path=/tmp/app
+    export unprivileged_user=\$(whoami)
+    export unprivileged_group=\$(id -gn)
+
+    rm -rf \$buildpack_path && mkdir -p \$buildpack_path
+    mkdir -p \$build_path
+
+    # Seed two default buildpacks: a realistic multi that only detects when
+    # .buildpacks exists, and a ruby stub that always detects. Under the old
+    # flow both would match and trigger the misleading 'Multiple default
+    # buildpacks' warning.
+    mkdir -p \$buildpack_path/00_buildpack-multi/bin
+    {
+      echo '#!/usr/bin/env bash'
+      echo '[[ -f \"\$1/.buildpacks\" ]] && { echo Multipack; exit 0; }'
+      echo 'exit 1'
+    } > \$buildpack_path/00_buildpack-multi/bin/detect
+    chmod +x \$buildpack_path/00_buildpack-multi/bin/detect
+
+    mkdir -p \$buildpack_path/01_buildpack-ruby/bin
+    {
+      echo '#!/usr/bin/env bash'
+      echo 'echo Ruby'
+    } > \$buildpack_path/01_buildpack-ruby/bin/detect
+    chmod +x \$buildpack_path/01_buildpack-ruby/bin/detect
+
+    # Build a local git repo to act as the single custom buildpack that
+    # .buildpacks points at. Using file:// avoids network dependencies and
+    # exercises the real buildpack-install git-clone path.
+    local_bp=/tmp/single-custom-buildpack
+    rm -rf \$local_bp
+    mkdir -p \$local_bp/bin
+    {
+      echo '#!/usr/bin/env bash'
+      echo 'echo SingleCustom'
+    } > \$local_bp/bin/detect
+    chmod +x \$local_bp/bin/detect
+    (
+      cd \$local_bp
+      git init -q
+      git config user.email t@t
+      git config user.name t
+      git add -A
+      git commit -q -m init
+    )
+
+    # Declare exactly one buildpack; should be treated like BUILDPACK_URL.
+    echo \"file://\$local_bp\" > \$build_path/.buildpacks
+
+    set +e
+    output=\$(herokuish buildpack detect 2>&1)
+    rc=\$?
+    set -e
+    if [[ \"\$rc\" -ne 0 ]]; then
+      echo 'expected exit 0, got' \"\$rc\"
+      echo \"\$output\"
+      exit 1
+    fi
+    if echo \"\$output\" | grep -q 'Multiple default buildpacks reported'; then
+      echo 'unexpected multi warning in output:'
+      echo \"\$output\"
+      exit 1
+    fi
+    if echo \"\$output\" | grep -q 'Multipack app detected'; then
+      echo 'unexpected Multipack selection in output:'
+      echo \"\$output\"
+      exit 1
+    fi
+    echo \"\$output\" | grep -q 'SingleCustom app detected'
+  "
+}
+
 @test "buildpack-detect-bad-buildpack-url" {
   herokuish-test "buildpack-detect-bad-buildpack-url" "
     set +e

--- a/tests/unit/tests.bats
+++ b/tests/unit/tests.bats
@@ -99,6 +99,203 @@
   }
 }
 
+# Helpers for the issue #554 _select-buildpack tests. Each test calls
+# _select-buildpack-setup first to source buildpack.bash, scope buildpack_path
+# and build_path to a tmpdir, stub outer-scope dependencies (title/indent/
+# chown/unprivileged/buildpack-install), and set up a capture file at
+# $_select_buildpack_install_args. The stubbed buildpack-install records its
+# args and fabricates $buildpack_path/custom/bin/detect so the post-install
+# detect step in _select-buildpack still produces a selected_name.
+_select-buildpack-setup() {
+  # shellcheck disable=SC1091
+  source "${BATS_TEST_DIRNAME}/../../include/buildpack.bash"
+  _select_buildpack_root="$(mktemp -d)"
+  # shellcheck disable=SC2034
+  buildpack_path="$_select_buildpack_root/buildpacks"
+  # shellcheck disable=SC2034
+  build_path="$_select_buildpack_root/build"
+  mkdir -p "$buildpack_path" "$build_path"
+  # shellcheck disable=SC2034
+  unprivileged_user="$(id -un)"
+  # shellcheck disable=SC2034
+  unprivileged_group="$(id -gn)"
+  _select_buildpack_install_args="$_select_buildpack_root/install-args"
+  : >"$_select_buildpack_install_args"
+  # shellcheck disable=SC2317
+  title() { echo "-----> $*"; }
+  # shellcheck disable=SC2317
+  indent() { sed -e 's/^/       /'; }
+  # shellcheck disable=SC2317
+  chown() { :; }
+  # shellcheck disable=SC2317
+  unprivileged() { command "$@"; }
+  # shellcheck disable=SC2317
+  buildpack-install() {
+    echo "$1|$2|$3" >>"$_select_buildpack_install_args"
+    mkdir -p "$buildpack_path/custom/bin"
+    cat >"$buildpack_path/custom/bin/detect" <<'DETECT'
+#!/usr/bin/env bash
+echo Custom
+DETECT
+    command chmod +x "$buildpack_path/custom/bin/detect"
+  }
+}
+
+@test "select-buildpack-single-url-in-dotbuildpacks-promoted-to-url" {
+  # Issue #554: a single URL in .buildpacks must be treated like BUILDPACK_URL.
+  _select-buildpack-setup
+  echo "https://github.com/heroku/heroku-buildpack-ruby" >"$build_path/.buildpacks"
+  unset BUILDPACK_URL
+
+  run _select-buildpack
+  local install_args
+  install_args="$(cat "$_select_buildpack_install_args")"
+  rm -rf "$_select_buildpack_root"
+
+  [[ "$status" -eq 0 ]] || {
+    echo "expected exit 0, got $status; output: $output"
+    return 1
+  }
+  [[ "$install_args" == "https://github.com/heroku/heroku-buildpack-ruby||custom" ]] || {
+    echo "expected buildpack-install to be called with the single URL, got: '$install_args'"
+    return 2
+  }
+  [[ "$output" != *"Multiple default buildpacks"* ]] || {
+    echo "expected no 'Multiple default buildpacks' warning, got: $output"
+    return 3
+  }
+  [[ "$output" == *"Fetching custom buildpack"* ]] || {
+    echo "expected 'Fetching custom buildpack' title, got: $output"
+    return 4
+  }
+}
+
+@test "select-buildpack-single-url-with-comments-and-blanks" {
+  # Comments and blank lines must be ignored when counting URLs.
+  _select-buildpack-setup
+  cat >"$build_path/.buildpacks" <<'EOF'
+# this is a comment
+
+  # indented comment
+   https://github.com/heroku/heroku-buildpack-ruby
+
+EOF
+  unset BUILDPACK_URL
+
+  run _select-buildpack
+  local install_args
+  install_args="$(cat "$_select_buildpack_install_args")"
+  rm -rf "$_select_buildpack_root"
+
+  [[ "$status" -eq 0 ]] || {
+    echo "expected exit 0, got $status; output: $output"
+    return 1
+  }
+  [[ "$install_args" == "https://github.com/heroku/heroku-buildpack-ruby||custom" ]] || {
+    echo "expected single trimmed URL, got: '$install_args'"
+    return 2
+  }
+  [[ "$output" != *"Multiple default buildpacks"* ]] || {
+    echo "expected no 'Multiple default buildpacks' warning, got: $output"
+    return 3
+  }
+}
+
+@test "select-buildpack-multiple-urls-uses-default-flow" {
+  # 2+ URLs in .buildpacks must fall through to the default (multi) flow,
+  # i.e. buildpack-install through the custom path must NOT be invoked.
+  _select-buildpack-setup
+  cat >"$build_path/.buildpacks" <<'EOF'
+https://github.com/heroku/heroku-buildpack-ruby
+https://github.com/heroku/heroku-buildpack-nodejs
+EOF
+  unset BUILDPACK_URL
+
+  # Seed a multi buildpack so the fallthrough path has something to detect.
+  mkdir -p "$buildpack_path/00_buildpack-multi/bin"
+  cat >"$buildpack_path/00_buildpack-multi/bin/detect" <<'EOF'
+#!/usr/bin/env bash
+echo Multipack
+EOF
+  command chmod +x "$buildpack_path/00_buildpack-multi/bin/detect"
+
+  run _select-buildpack
+  local install_args
+  install_args="$(cat "$_select_buildpack_install_args")"
+  rm -rf "$_select_buildpack_root"
+
+  [[ "$status" -eq 0 ]] || {
+    echo "expected exit 0, got $status; output: $output"
+    return 1
+  }
+  [[ -z "$install_args" ]] || {
+    echo "expected buildpack-install NOT to be called via URL path, got: '$install_args'"
+    return 2
+  }
+  [[ "$output" == *"Multipack app detected"* ]] || {
+    echo "expected 'Multipack app detected' via multi flow, got: $output"
+    return 3
+  }
+}
+
+@test "select-buildpack-buildpack-url-wins-over-dotbuildpacks" {
+  # Callers that pre-set BUILDPACK_URL must keep precedence over .buildpacks.
+  _select-buildpack-setup
+  echo "https://github.com/in-file" >"$build_path/.buildpacks"
+  export BUILDPACK_URL="https://github.com/from-env"
+
+  run _select-buildpack
+  local install_args
+  install_args="$(cat "$_select_buildpack_install_args")"
+  unset BUILDPACK_URL
+  rm -rf "$_select_buildpack_root"
+
+  [[ "$status" -eq 0 ]] || {
+    echo "expected exit 0, got $status; output: $output"
+    return 1
+  }
+  [[ "$install_args" == "https://github.com/from-env||custom" ]] || {
+    echo "expected BUILDPACK_URL value to be used, got: '$install_args'"
+    return 2
+  }
+}
+
+@test "select-buildpack-comment-only-dotbuildpacks-falls-through" {
+  # A .buildpacks file with zero real URLs must fall through to the default
+  # flow (same as "no file"), not hijack the custom path with an empty URL.
+  _select-buildpack-setup
+  cat >"$build_path/.buildpacks" <<'EOF'
+# only a comment
+
+EOF
+  unset BUILDPACK_URL
+
+  mkdir -p "$buildpack_path/00_buildpack-ruby/bin"
+  cat >"$buildpack_path/00_buildpack-ruby/bin/detect" <<'EOF'
+#!/usr/bin/env bash
+echo Ruby
+EOF
+  command chmod +x "$buildpack_path/00_buildpack-ruby/bin/detect"
+
+  run _select-buildpack
+  local install_args
+  install_args="$(cat "$_select_buildpack_install_args")"
+  rm -rf "$_select_buildpack_root"
+
+  [[ "$status" -eq 0 ]] || {
+    echo "expected exit 0, got $status; output: $output"
+    return 1
+  }
+  [[ -z "$install_args" ]] || {
+    echo "expected buildpack-install NOT to be called, got: '$install_args'"
+    return 2
+  }
+  [[ "$output" == *"Ruby app detected"* ]] || {
+    echo "expected 'Ruby app detected' via default flow, got: $output"
+    return 3
+  }
+}
+
 @test "procfile-parse-valid" {
   # shellcheck disable=SC1091
   source "${BATS_TEST_DIRNAME}/../../include/procfile.bash"


### PR DESCRIPTION
## Summary

Closes #554.

When a user declares a single custom buildpack via `.buildpacks` (e.g. via
`dokku buildpacks:add <url>`), `heroku-buildpack-multi` and the underlying
language buildpack both report detection success. That trips
`_select-buildpack`'s "Multiple default buildpacks reported" warning even
though the user declared exactly one buildpack — there is no real ambiguity.

This change promotes a single-entry `.buildpacks` file to `BUILDPACK_URL`
at the top of `_select-buildpack`, so the existing custom-buildpack path
runs directly. `heroku-buildpack-multi` is skipped entirely for the
one-URL case, eliminating the misleading warning and the redundant
"Multipack app detected" preamble. Files with 2+ entries still flow
through `heroku-buildpack-multi`, and an explicit `BUILDPACK_URL` always
wins over the file.

## Before / after

Before (`dokku buildpacks:add https://github.com/user/heroku-buildpack-ruby`):

```
-----> Warning: Multiple default buildpacks reported the ability to handle this app. The first buildpack in the list below will be used.
       Detected buildpacks: multi ruby
-----> Multipack app detected
=====> Downloading Buildpack: https://github.com/user/heroku-buildpack-ruby
=====> Detected Framework: Ruby
```

After:

```
-----> Fetching custom buildpack
-----> Ruby app detected
```