### PR TITLE
Install rng-tools5 and add HEROKUISH_ENTROPY opt-in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 LABEL com.gliderlabs.herokuish/stack=$STACK
 
 USER root
-# for setuidgid
+# for setuidgid (daemontools) and optional /dev/random seeding (rng-tools5)
 COPY bin/apt-install /usr/local/bin/apt-install
-RUN apt-install daemontools
 COPY --from=builder /src/herokuish /bin/
 
-RUN apt-install daemontools && \
+RUN apt-install daemontools rng-tools5 && \
     /bin/herokuish buildpack install \
     && ln -s /bin/herokuish /build \
     && ln -s /bin/herokuish /start \

--- a/README.md
+++ b/README.md
@@ -218,6 +218,16 @@ Note that the underlying buildpacks will not trace their commands with `TRACE=tr
 
 If `BUILDPACK_URL` is not set and the app's build directory contains a `.buildpacks` file with exactly one entry, herokuish treats that entry as `BUILDPACK_URL`. This bypasses `heroku-buildpack-multi` (and its "Multiple default buildpacks reported" warning) when only one buildpack is declared, since there is no real ambiguity. A `.buildpacks` file with two or more entries still goes through `heroku-buildpack-multi` as before. An explicit `BUILDPACK_URL` always wins over the file.
 
+### Entropy for `/dev/random`
+
+Workloads built on `libsodium` (used by `libzmq`, `pyzmq`, and transitively by Jupyter/`voila`) can hang on startup when the container's kernel entropy pool is not yet seeded. The runtime image ships with `rng-tools5` (which provides `rngd`) and will start it before `procfile-exec` hands off to the application when `HEROKUISH_ENTROPY=true` is set:
+
+```shell
+docker run --rm --cap-add=SYS_ADMIN -e HEROKUISH_ENTROPY=true gliderlabs/herokuish /start web
+```
+
+`rngd` needs `CAP_SYS_ADMIN` to inject entropy into `/dev/random`; without it the daemon either no-ops or logs a warning (`!     rngd failed to start`), and the application is still executed. The setting is off by default to preserve existing behavior — enable it only if you are seeing startup hangs caused by entropy starvation (see gliderlabs/herokuish#659).
+
 ## Contributing
 
 Pull requests are welcome! Herokuish is written in Bash and Go. Please conform to the [Bash styleguide](https://github.com/progrium/bashstyle) used for this project when writing Bash.

--- a/include/procfile.bash
+++ b/include/procfile.bash
@@ -47,6 +47,7 @@ procfile-start() {
 procfile-exec() {
   declare desc="Run as unprivileged user with Heroku-like env"
   [[ "$USER" ]] || detect-unprivileged
+  procfile-ensure-entropy
   procfile-setup-home
   cd "$app_path" || return 1
   procfile-load-env
@@ -57,6 +58,21 @@ procfile-exec() {
     exec $(eval echo "$@")
   else
     exec setuidgid "$unprivileged_user" $(eval echo "$@")
+  fi
+}
+
+procfile-ensure-entropy() {
+  declare desc="Start rngd to seed /dev/random when HEROKUISH_ENTROPY=true"
+  [[ "$HEROKUISH_ENTROPY" == "true" ]] || return 0
+  if ! command -v rngd >/dev/null 2>&1; then
+    echo "!     HEROKUISH_ENTROPY=true but rngd is not installed; skipping" >&2
+    return 0
+  fi
+  if pgrep -x rngd >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! rngd -b >/dev/null 2>&1; then
+    echo "!     rngd failed to start; /dev/random may block (need CAP_SYS_ADMIN?)" >&2
   fi
 }
 

--- a/tests/functional/tests.bats
+++ b/tests/functional/tests.bats
@@ -41,6 +41,16 @@ teardown_file() {
   herokuish-test "test-user" "$(fn-source _test-user)"
 }
 
+# rng-tools5 is shipped in the image so operators can opt into seeding
+# /dev/random via HEROKUISH_ENTROPY=true. See gliderlabs/herokuish#659.
+@test "rng-tools-installed" {
+  _test-rngd-present() {
+    # shellcheck disable=SC2317
+    command -v rngd
+  }
+  herokuish-test "test-rngd-present" "$(fn-source _test-rngd-present)"
+}
+
 @test "generate-slug" {
   herokuish-test "test-slug-generate" "
 		herokuish slug generate

--- a/tests/unit/tests.bats
+++ b/tests/unit/tests.bats
@@ -482,3 +482,115 @@ EOF
     return 1
   }
 }
+
+# procfile-ensure-entropy is the runtime hook that seeds /dev/random via rngd
+# when operators opt in with HEROKUISH_ENTROPY=true. See gliderlabs/herokuish#659.
+
+@test "procfile-ensure-entropy-default-off" {
+  # shellcheck disable=SC1091
+  source "${BATS_TEST_DIRNAME}/../../include/procfile.bash"
+  unset HEROKUISH_ENTROPY
+  export ENTROPY_TEST_MARKER
+  ENTROPY_TEST_MARKER="$(mktemp)"
+  # Fail loudly if the helper tries to call rngd when the flag is unset.
+  # shellcheck disable=SC2317
+  rngd() {
+    echo "rngd should not have been invoked" >"$ENTROPY_TEST_MARKER"
+    return 0
+  }
+  export -f rngd
+
+  run procfile-ensure-entropy
+  local marker="$ENTROPY_TEST_MARKER"
+  unset -f rngd
+  unset ENTROPY_TEST_MARKER
+
+  [[ "$status" -eq 0 ]] || {
+    echo "expected procfile-ensure-entropy to exit 0, got $status"
+    echo "output: $output"
+    rm -f "$marker"
+    return 1
+  }
+  if [[ -s "$marker" ]]; then
+    echo "procfile-ensure-entropy ran rngd without HEROKUISH_ENTROPY=true"
+    cat "$marker"
+    rm -f "$marker"
+    return 2
+  fi
+  rm -f "$marker"
+}
+
+@test "procfile-ensure-entropy-missing-rngd" {
+  # shellcheck disable=SC1091
+  source "${BATS_TEST_DIRNAME}/../../include/procfile.bash"
+  export HEROKUISH_ENTROPY=true
+  # Shadow `command` so the helper believes rngd is absent without depending
+  # on what's installed on the host.
+  # shellcheck disable=SC2317
+  command() {
+    if [[ "$1" == "-v" && "$2" == "rngd" ]]; then
+      return 1
+    fi
+    builtin command "$@"
+  }
+  export -f command
+
+  run procfile-ensure-entropy
+  unset -f command
+  unset HEROKUISH_ENTROPY
+
+  [[ "$status" -eq 0 ]] || {
+    echo "expected procfile-ensure-entropy to exit 0 when rngd is missing, got $status"
+    echo "output: $output"
+    return 1
+  }
+  [[ "$output" == *"rngd is not installed"* ]] || {
+    echo "expected warning about missing rngd, got: $output"
+    return 2
+  }
+}
+
+@test "procfile-ensure-entropy-opt-in" {
+  # shellcheck disable=SC1091
+  source "${BATS_TEST_DIRNAME}/../../include/procfile.bash"
+  export HEROKUISH_ENTROPY=true
+  export ENTROPY_TEST_MARKER
+  ENTROPY_TEST_MARKER="$(mktemp)"
+  # Stub pgrep so the helper believes rngd is not yet running, regardless of
+  # whether the host has any rngd running.
+  # shellcheck disable=SC2317
+  pgrep() { return 1; }
+  export -f pgrep
+  # Stub rngd so starting it is a cheap success that we can observe.
+  # Defining it as a function also satisfies `command -v rngd` without any
+  # further shadowing.
+  # shellcheck disable=SC2317
+  rngd() {
+    echo "started $*" >"$ENTROPY_TEST_MARKER"
+    return 0
+  }
+  export -f rngd
+
+  run procfile-ensure-entropy
+  local marker="$ENTROPY_TEST_MARKER"
+  unset -f pgrep rngd
+  unset HEROKUISH_ENTROPY ENTROPY_TEST_MARKER
+
+  [[ "$status" -eq 0 ]] || {
+    echo "expected procfile-ensure-entropy to exit 0, got $status"
+    echo "output: $output"
+    rm -f "$marker"
+    return 1
+  }
+  [[ -s "$marker" ]] || {
+    echo "procfile-ensure-entropy did not invoke rngd"
+    rm -f "$marker"
+    return 2
+  }
+  [[ "$(cat "$marker")" == "started -b" ]] || {
+    echo "expected rngd to be started with -b, got: $(cat "$marker")"
+    rm -f "$marker"
+    return 3
+  }
+  rm -f "$marker"
+}


### PR DESCRIPTION
## Summary

- Installs `rng-tools5` in the Heroku-24 runtime image alongside `daemontools`, and drops a duplicated `apt-install daemontools` step from the Dockerfile.
- Adds `procfile-ensure-entropy` in `include/procfile.bash`, called from `procfile-exec` before the `setuidgid` privilege drop. When `HEROKUISH_ENTROPY=true` is set, it starts `rngd -b` once (idempotent via `pgrep -x rngd`). A missing `rngd` binary or a failed launch (e.g., missing `CAP_SYS_ADMIN`) logs a single warning but does not abort the exec, so user code still runs.
- Default behavior is unchanged: without `HEROKUISH_ENTROPY=true` the helper is a no-op.
- Documents the new env var and the `CAP_SYS_ADMIN` requirement under a new "Entropy for `/dev/random`" section in `README.md`.
- Adds one functional bats case (`rng-tools-installed`) verifying `rngd` is present in the image, and three unit bats cases exercising the opt-in default-off contract, the missing-binary warning path, and a stubbed opt-in happy path.

Closes #659.