### PR TITLE
Bump Python to 3.9 in retag workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.7.x"
+          python-version: "3.9.x"
 
       - name: install docker-copyedit
         run: pip install docker-copyedit


### PR DESCRIPTION
## Summary
- Bumps Python from 3.7 to 3.9 in the release workflow's `retag` job
- `docker-copyedit` (used by `bin/retag`) requires Python 3.9+