### PR TITLE
Show buildpack name in fetch message

### DIFF
--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -56,7 +56,16 @@ _select-buildpack() {
   fi
 
   if [[ -n "$BUILDPACK_URL" ]]; then
-    title "Fetching custom buildpack"
+    # Compute display name: shorthand for GitHub, full URL otherwise
+    local display_name="$BUILDPACK_URL"
+    if [[ "$display_name" == https://github.com/* ]]; then
+      display_name="${display_name#https://github.com/}"
+      display_name="${display_name/.git/}"
+    elif [[ "$display_name" == git@github.com:* ]]; then
+      display_name="${display_name#git@github.com:}"
+      display_name="${display_name/.git/}"
+    fi
+    title "Fetching custom buildpack $display_name"
     # buildpack_path defined in outer scope
     # shellcheck disable=SC2154
     selected_path="$buildpack_path/custom"

--- a/tests/unit/tests.bats
+++ b/tests/unit/tests.bats
@@ -296,6 +296,51 @@ EOF
   }
 }
 
+@test "select-buildpack-fetch-message-shows-buildpack-name" {
+  # The "Fetching custom buildpack" title must include the buildpack identity.
+  # GitHub URLs are shortened to owner/repo; non-GitHub URLs are shown in full.
+  _select-buildpack-setup
+
+  # GitHub HTTPS with .git suffix and branch
+  export BUILDPACK_URL="https://github.com/heroku/heroku-buildpack-python.git#main"
+  run _select-buildpack
+  rm -rf "$_select_buildpack_root"
+  [[ "$output" == *"Fetching custom buildpack heroku/heroku-buildpack-python#main"* ]] || {
+    echo "GitHub HTTPS: expected shorthand with branch, got: $output"
+    return 1
+  }
+
+  # GitHub HTTPS without .git suffix or branch
+  _select-buildpack-setup
+  export BUILDPACK_URL="https://github.com/heroku/heroku-buildpack-ruby"
+  run _select-buildpack
+  rm -rf "$_select_buildpack_root"
+  [[ "$output" == *"Fetching custom buildpack heroku/heroku-buildpack-ruby"* ]] || {
+    echo "GitHub HTTPS plain: expected shorthand, got: $output"
+    return 2
+  }
+
+  # GitHub SSH with .git suffix
+  _select-buildpack-setup
+  export BUILDPACK_URL="git@github.com:heroku/heroku-buildpack-nodejs.git"
+  run _select-buildpack
+  rm -rf "$_select_buildpack_root"
+  [[ "$output" == *"Fetching custom buildpack heroku/heroku-buildpack-nodejs"* ]] || {
+    echo "GitHub SSH: expected shorthand, got: $output"
+    return 3
+  }
+
+  # Non-GitHub URL shown in full
+  _select-buildpack-setup
+  export BUILDPACK_URL="https://example.com/custom-buildpack#v2"
+  run _select-buildpack
+  rm -rf "$_select_buildpack_root"
+  [[ "$output" == *"Fetching custom buildpack https://example.com/custom-buildpack#v2"* ]] || {
+    echo "Non-GitHub: expected full URL with branch, got: $output"
+    return 4
+  }
+}
+
 @test "procfile-parse-valid" {
   # shellcheck disable=SC1091
   source "${BATS_TEST_DIRNAME}/../../include/procfile.bash"


### PR DESCRIPTION
## Summary

- Display the buildpack identity in the "Fetching custom buildpack" message
- GitHub URLs (HTTPS and SSH) are shortened to `owner/repo` format, non-GitHub URLs shown in full
- `.git` suffix is stripped and `#branch` fragments are preserved