### PR TITLE
Replace docker-copyedit with regctl for image retagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,24 +67,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: set up qemu
-        uses: docker/setup-qemu-action@v4
-
-      - name: set up docker buildx
-        uses: docker/setup-buildx-action@v4
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.9.x"
-
-      - name: install docker-copyedit
-        run: pip install docker-copyedit
+      - name: install regctl
+        uses: regclient/actions/regctl-installer@main
 
       - name: Get the version
         id: get_version
         run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: retag images
-        env:
-          DOCKER_CLI_EXPERIMENTAL: enabled
         run: bin/retag ${{ steps.get_version.outputs.VERSION }}

--- a/bin/retag
+++ b/bin/retag
@@ -10,50 +10,15 @@ main() {
     exit 1
   fi
 
-  architectures=(amd64 arm64)
+  echo "====> Removing label from ${IMAGE}:${TAG}"
+  regctl image mod "${IMAGE}:${TAG}" --replace \
+    --label "io.buildpacks.stack.id="
 
-  echo "====> Deleting all existing manifests"
-  tags=("${TAG}" "${TAG}-24" "latest" "latest-24")
+  echo "====> Copying ${IMAGE}:${TAG} to additional tags"
+  tags=("${TAG}-24" "latest" "latest-24")
   for tag in "${tags[@]}"; do
-    if docker manifest inspect "${IMAGE}:${tag}" 2>/dev/null; then
-      echo "      Deleting manifest for ${IMAGE}:${tag}"
-      docker manifest rm "${IMAGE}:${tag}" || true
-    fi
-  done
-
-  echo "====> Processing $IMAGE:$TAG"
-  for architecture in "${architectures[@]}"; do
-    echo "----> Processing ${architecture}"
-    echo "      Pulling ${IMAGE}:${TAG} for ${architecture}"
-    docker image pull --platform "linux/${architecture}" "${IMAGE}:${TAG}"
-    docker image tag "${IMAGE}:${TAG}" "${IMAGE}:${TAG}-${architecture}"
-    docker image rm "${IMAGE}:${TAG}"
-
-    echo "      Removing label from ${IMAGE}:${TAG}-${architecture}"
-    docker-copyedit.py \
-      FROM "${IMAGE}:${TAG}-${architecture}" \
-      INTO "${IMAGE}:${TAG}-${architecture}-patched" \
-      REMOVE LABEL io.buildpacks.stack.id
-    echo "      Tagging ${IMAGE}:${TAG}-${architecture}-patched as ${IMAGE}:${TAG}-${architecture}"
-    docker image rm "${IMAGE}:${TAG}-${architecture}"
-    docker image tag "${IMAGE}:${TAG}-${architecture}-patched" "${IMAGE}:${TAG}-${architecture}"
-    echo "      Pushing ${IMAGE}:${TAG}-${architecture}"
-    docker image push "${IMAGE}:${TAG}-${architecture}"
-  done
-
-  echo "----> Creating manifests"
-  tags=("${TAG}" "${TAG}-24" "latest" "latest-24")
-  for tag in "${tags[@]}"; do
-    echo "      Creating manifest for ${IMAGE}:${tag}"
-    docker manifest create "${IMAGE}:${tag}" \
-      --amend "${IMAGE}:${TAG}-amd64" \
-      --amend "${IMAGE}:${TAG}-arm64"
-  done
-
-  echo "----> Pushing manifests"
-  for tag in "${tags[@]}"; do
-    echo "      Pushing manifest for ${IMAGE}:${tag}"
-    docker manifest push "${IMAGE}:${tag}"
+    echo "----> Copying to ${IMAGE}:${tag}"
+    regctl image copy "${IMAGE}:${TAG}" "${IMAGE}:${tag}"
   done
 
   echo " !    Done!"


### PR DESCRIPTION
## Summary

- Replace `docker-copyedit` (broken Python package) with `regctl` from [regclient](https://github.com/regclient/regclient) for removing the `io.buildpacks.stack.id` label during release retagging
- Simplify `bin/retag` from ~62 lines to ~28 lines by using `regctl image mod --replace` (operates directly on registry, no local pull/push) and `regctl image copy` for additional tags
- Remove QEMU, Buildx, Python, and docker-copyedit dependencies from the retag CI job

Closes #1879