### PR TITLE
Strip io.buildpacks.stack.id before push and verify after

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       - "*"
 
 jobs:
-  build:
+  release:
     name: release
     runs-on: ubuntu-22.04
     strategy:
@@ -21,13 +21,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Get the version
         id: get_version
@@ -48,18 +41,13 @@ jobs:
           echo "Flags:     ${{ steps.buildx.outputs.flags }}"
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
 
-      - name: Build herokuish
+      - name: Build herokuish (OCI layout, not pushed)
         run: |
           export PATH="/home/runner/go/bin:$PATH"
-          make build/docker/${{ matrix.heroku }} IMAGE_NAME="$GITHUB_REPOSITORY" BUILD_TAG=${{ steps.get_version.outputs.VERSION }} VERSION=${{ steps.get_version.outputs.VERSION }} DOCKER_ARGS="--push" STACK_VERSION=${{ matrix.heroku }}
+          make build/docker/${{ matrix.heroku }} IMAGE_NAME="$GITHUB_REPOSITORY" BUILD_TAG=${{ steps.get_version.outputs.VERSION }} VERSION=${{ steps.get_version.outputs.VERSION }} STACK_VERSION=${{ matrix.heroku }} OCI_OUTPUT=build/oci/herokuish.tar
 
-  retag:
-    name: retag
-    needs: build
-    runs-on: ubuntu-22.04
-
-    steps:
-      - uses: actions/checkout@v6
+      - name: install regctl
+        uses: regclient/actions/regctl-installer@main
 
       - name: Login to DockerHub
         uses: docker/login-action@v4
@@ -67,12 +55,5 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: install regctl
-        uses: regclient/actions/regctl-installer@main
-
-      - name: Get the version
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
-
-      - name: retag images
-        run: bin/retag ${{ steps.get_version.outputs.VERSION }}
+      - name: Strip label, push, and verify
+        run: bin/retag ${{ steps.get_version.outputs.VERSION }} build/oci/herokuish.tar

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ build/docker:
 	$(MAKE) build/docker/24 STACK_VERSION=24
 
 build/docker/$(STACK_VERSION): bindata.go
+ifneq ($(OCI_OUTPUT),)
+	mkdir -p $(dir $(OCI_OUTPUT))
+	docker buildx build --no-cache --pull --progress plain --platform linux/arm64/v8,linux/amd64 --build-arg STACK_VERSION=$(STACK_VERSION) --build-arg VERSION=$(VERSION) --output type=oci,dest=$(OCI_OUTPUT) -t $(IMAGE_NAME):$(BUILD_TAG) .
+else
 ifeq ($(BUILDX),true)
 ifeq ($(STACK_VERSION),24)
 	docker buildx build --no-cache ${DOCKER_ARGS} --pull --progress plain --platform linux/arm64/v8,linux/amd64 --build-arg STACK_VERSION=$(STACK_VERSION) --build-arg VERSION=$(VERSION) -t $(IMAGE_NAME):$(BUILD_TAG)-$(STACK_VERSION) -t $(IMAGE_NAME):latest-$(STACK_VERSION) -t $(IMAGE_NAME):$(BUILD_TAG) -t $(IMAGE_NAME):latest .
@@ -66,6 +70,7 @@ else
 endif
 else
 	docker build --no-cache ${DOCKER_ARGS} --pull --progress plain --build-arg STACK_VERSION=$(STACK_VERSION) --build-arg VERSION=$(VERSION) -t $(IMAGE_NAME):$(BUILD_TAG)-$(STACK_VERSION) -t $(IMAGE_NAME):latest-$(STACK_VERSION) -t $(IMAGE_NAME):$(BUILD_TAG) .
+endif
 endif
 
 build/deb:

--- a/bin/retag
+++ b/bin/retag
@@ -1,27 +1,70 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+IMAGE=gliderlabs/herokuish
+
 main() {
   declare TAG="$1"
-  IMAGE=gliderlabs/herokuish
+  declare OCI_TAR="${2:-build/oci/herokuish.tar}"
+  local OCI_DIR
+  OCI_DIR="$(dirname "$OCI_TAR")/oci-layout"
 
   if [ -z "$TAG" ]; then
-    echo "Usage: $0 <tag>"
+    echo "Usage: $0 <tag> [oci-tarball-path]"
     exit 1
   fi
 
-  echo "====> Removing label from ${IMAGE}:${TAG}"
-  regctl image mod "${IMAGE}:${TAG}" --replace \
+  if [ ! -f "$OCI_TAR" ]; then
+    echo " !    OCI tarball not found at ${OCI_TAR}"
+    exit 1
+  fi
+
+  echo "====> Extracting OCI layout from ${OCI_TAR}"
+  rm -rf "$OCI_DIR"
+  mkdir -p "$OCI_DIR"
+  tar -xf "$OCI_TAR" -C "$OCI_DIR"
+
+  echo "====> Stripping io.buildpacks.stack.id from local OCI layout"
+  regctl image mod "ocidir://${OCI_DIR}:${TAG}" --replace \
     --label "io.buildpacks.stack.id="
 
-  echo "====> Copying ${IMAGE}:${TAG} to additional tags"
-  tags=("${TAG}-24" "latest" "latest-24")
+  echo "====> Pushing cleaned image to Docker Hub"
+  local tags=("${TAG}" "${TAG}-24" "latest" "latest-24")
   for tag in "${tags[@]}"; do
-    echo "----> Copying to ${IMAGE}:${tag}"
-    regctl image copy "${IMAGE}:${TAG}" "${IMAGE}:${tag}"
+    echo "----> Pushing to ${IMAGE}:${tag}"
+    regctl image copy "ocidir://${OCI_DIR}:${TAG}" "${IMAGE}:${tag}"
   done
 
+  verify_labels "$TAG"
   echo " !    Done!"
+}
+
+verify_labels() {
+  declare TAG="$1"
+  local all_tags=("${TAG}" "${TAG}-24" "latest" "latest-24")
+  local platforms=("linux/amd64" "linux/arm64/v8")
+  local failed=0
+  local label
+
+  echo "====> Verifying io.buildpacks.stack.id is absent on all tags"
+  for tag in "${all_tags[@]}"; do
+    for platform in "${platforms[@]}"; do
+      label=$(regctl image config "${IMAGE}:${tag}" \
+        --platform "${platform}" \
+        --format '{{ index .config.Labels "io.buildpacks.stack.id" }}')
+      if [ -n "${label}" ]; then
+        echo " !    ${IMAGE}:${tag} (${platform}) still has io.buildpacks.stack.id=${label}"
+        failed=1
+      else
+        echo "----> ok: ${IMAGE}:${tag} (${platform})"
+      fi
+    done
+  done
+
+  if [ "${failed}" -ne 0 ]; then
+    echo " !    Label verification failed"
+    exit 1
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
The previous release shipped images that still carried the `io.buildpacks.stack.id` label because the post-push `regctl image mod` step failed silently and nothing in CI checked the result. This is a follow-up to #1880 (which closed #1879): it moves the label strip to before any Docker Hub push and adds an explicit verification gate after publish, so a silent failure can no longer ship.