### PR TITLE
Make extracted OCI layout writable before regctl image mod

### DIFF
--- a/bin/retag
+++ b/bin/retag
@@ -23,6 +23,7 @@ main() {
   rm -rf "$OCI_DIR"
   mkdir -p "$OCI_DIR"
   tar -xf "$OCI_TAR" -C "$OCI_DIR"
+  chmod -R u+w "$OCI_DIR"
 
   echo "====> Stripping io.buildpacks.stack.id from local OCI layout"
   regctl image mod "ocidir://${OCI_DIR}:${TAG}" --replace \


### PR DESCRIPTION
## Summary

`docker buildx build --output type=oci,dest=...` produces a tar whose inner `oci-layout` index file is read-only, so extracting it preserves those perms and `regctl image mod --replace` aborts with `cannot create oci-layout: ... permission denied`. Chmod the extracted layout writable before stripping the label.

This surfaced on the `v0.11.12` release run: https://github.com/gliderlabs/herokuish/actions/runs/26317859135/job/77480749721