### PR TITLE
Use capitalized field in retag verify template

### DIFF
--- a/bin/retag
+++ b/bin/retag
@@ -52,7 +52,7 @@ verify_labels() {
     for platform in "${platforms[@]}"; do
       label=$(regctl image config "${IMAGE}:${tag}" \
         --platform "${platform}" \
-        --format '{{ index .config.Labels "io.buildpacks.stack.id" }}')
+        --format '{{ index .Config.Labels "io.buildpacks.stack.id" }}')
       if [ -n "${label}" ]; then
         echo " !    ${IMAGE}:${tag} (${platform}) still has io.buildpacks.stack.id=${label}"
         failed=1


### PR DESCRIPTION
The verify step in `bin/retag` passes `{{ index .config.Labels ... }}` to `regctl image config --format`, but the struct embeds `v1.Image` whose field is `Config`. Go templates do case-sensitive field lookup, so the lowercase reference fails with `can't evaluate field config` and the release job goes red even after the push succeeds. Switching to `.Config.Labels` lets the verification run as intended.