### PR TITLE
chore: publish deb to ubuntu/resolute on packagecloud

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ release-packagecloud: package_cloud
 release-packagecloud-deb: package_cloud build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy   build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/noble   build/deb/$(NAME)_$(VERSION)_all.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/resolute build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/stretch build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bookworm build/deb/$(NAME)_$(VERSION)_all.deb


### PR DESCRIPTION
Ubuntu 26.04 LTS (Resolute Raccoon, codename `resolute`) has no matching PackageCloud distribution for the herokuish `.deb`, so installs on 26.04 cannot pull the package. Add an `ubuntu/resolute` push line to the `release-packagecloud-deb` target mirroring `ubuntu/noble` so the same architecture-independent package is published for the new release.

Ref: dokku/dokku#8768

Closes #1947
