### PR TITLE
chore(deps): bump django to 6.0.7 to fix CVE-2026-7666

### DIFF
--- a/buildpacks/buildpack-python/tests/python-django/requirements.txt
+++ b/buildpacks/buildpack-python/tests/python-django/requirements.txt
@@ -1,2 +1,2 @@
-django==6.0.4
+django==6.0.7
 gunicorn==26.0.0


### PR DESCRIPTION
Dependabot alert [152](https://github.com/gliderlabs/herokuish/security/dependabot/152) flags `django==6.0.4` pinned in the Python buildpack's Django test fixture at `buildpacks/buildpack-python/tests/python-django/requirements.txt`. The advisory GHSA-mm6v-q8q9-pgcf (CVE-2026-7666, CWE-319, low severity) reports that `django.core.mail.backends.smtp.EmailBackend` fails to prevent reuse of a partially-initialized connection after a failed `STARTTLS` handshake when `fail_silently=True`, allowing on-path network attackers to read email content over cleartext. The vulnerable range is `>= 6.0, < 6.0.6`, first patched in `6.0.6`.

This bumps Django to `6.0.7`, the latest patch in the 6.0 series and past the first-patched version, matching the repository convention of pinning to the latest available patch. Because this is a patch-level bump within the same 6.0 minor series, `helloworld/settings.py` needs no changes and its `docs.djangoproject.com/en/6.0/` references remain valid. Django 6.0.7 requires Python `>=3.12`, which the fixture's pinned Python `3.13.13` satisfies. `gunicorn==26.0.0` is left unchanged as it is already the latest release.

The fixture is a hello-world Django app used to verify the Python buildpack builds and boots a Django app, and has no email functionality, so the advisory has no practical impact here, but the pin is moved out of the vulnerable range to resolve the alert. The existing bats integration test at `buildpacks/buildpack-python/tests/python-django/test.bats` continues to cover the fixture by building and booting the app through the buildpack, which exercises installing the new pin.
