### PR TITLE
Fix stderr access

### DIFF
--- a/buildpacks/test_helper.bash
+++ b/buildpacks/test_helper.bash
@@ -9,5 +9,5 @@ _run-cmd() {
   [[ "$CI" ]] || rmflag="--rm"
   [[ "$TRACE" ]] && debug_flag="-e TRACE=true"
   # shellcheck disable=SC2086
-  docker run -t $rmflag $debug_flag --env=USER=herokuishuser -e HEROKUISH_WITH_TTY=true -v "$app_path:/tmp/app" herokuish:dev /bin/herokuish $cmd / "$app"
+  docker run -t $rmflag $debug_flag --env=USER=herokuishuser -v "$app_path:/tmp/app" herokuish:dev /bin/herokuish $cmd / "$app"
 }

--- a/include/buildpack.bash
+++ b/include/buildpack.bash
@@ -109,9 +109,6 @@ buildpack-detect() {
   declare desc="Detect suitable buildpack for an application"
   ensure-paths
   [[ "$USER" ]] || randomize-unprivileged
-  if [[ -n "$HEROKUISH_WITH_TTY" ]]; then
-    usermod -aG tty "$unprivileged_user" 2>/dev/null || true
-  fi
   buildpack-setup >/dev/null
   _select-buildpack
 }
@@ -120,9 +117,6 @@ buildpack-build() {
   declare desc="Build an application using installed buildpacks"
   ensure-paths
   [[ "$USER" ]] || randomize-unprivileged
-  if [[ -n "$HEROKUISH_WITH_TTY" ]]; then
-    usermod -aG tty "$unprivileged_user" 2>/dev/null || true
-  fi
   buildpack-setup >/dev/null
   buildpack-execute | indent
   procfile-types | indent
@@ -310,9 +304,6 @@ buildpack-test() {
   declare desc="Build and run tests for an application using installed buildpacks"
   ensure-paths
   [[ "$USER" ]] || randomize-unprivileged
-  if [[ -n "$HEROKUISH_WITH_TTY" ]]; then
-    usermod -aG tty "$unprivileged_user" 2>/dev/null || true
-  fi
   buildpack-setup >/dev/null
   _select-buildpack
 

--- a/include/default_user.bash
+++ b/include/default_user.bash
@@ -12,7 +12,3 @@ addgroup --quiet --gid "32767" "herokuishuser" \
     --quiet \
     --home "/app" \
     "herokuishuser"
-
-if [ -n "$HEROKUISH_WITH_TTY" ]; then
-  usermod -aG tty herokuishuser
-fi

--- a/include/herokuish.bash
+++ b/include/herokuish.bash
@@ -59,11 +59,7 @@ indent() {
 }
 
 unprivileged() {
-  if [ -n "$HEROKUISH_WITH_TTY" ]; then
-    runuser -u "$unprivileged_user" -- "$@"
-  else
-    setuidgid "$unprivileged_user" "$@"
-  fi
+  setuidgid "$unprivileged_user" "$@"
 }
 
 detect-unprivileged() {
@@ -87,10 +83,6 @@ randomize-unprivileged() {
     --quiet \
     --home "$app_path" \
     "$username"
-
-  if [ -n "$HEROKUISH_WITH_TTY" ]; then
-    usermod -aG tty "$username"
-  fi
 
   unprivileged_user="$username"
   unprivileged_group="$username"

--- a/include/herokuish.bash
+++ b/include/herokuish.bash
@@ -59,6 +59,7 @@ indent() {
 }
 
 unprivileged() {
+  chown "$unprivileged_user" /dev/std*
   setuidgid "$unprivileged_user" "$@"
 }
 


### PR DESCRIPTION
Resolves #1818 without the need for TTY.

After a lot of try and error, I was finally able to find the cause. The pipe where `/proc/self/fd/1` and `/proc/self/fd/2` points to are owned by root.

I propose two possible solutions.
1. Use FIFO, make the unprivileged user the owner, send the outputs to the roots stdin and stderr, then direct setuidgid stdin/stderr to the FIFOs.
2. Use process substitution to alter stdin/stderr inside the execution of setuidgid. It uses exec and quite unreadable but short.